### PR TITLE
Release 0.1.3: sync reliability, session recovery, Airlock 0.2.1

### DIFF
--- a/Sources/App/FoodleApp.swift
+++ b/Sources/App/FoodleApp.swift
@@ -38,7 +38,12 @@ struct FoodleApp: App {
                     logger.info("Ignoring stale URL on launch: \(url.scheme ?? "nil", privacy: .public)")
                 }
         }
-        .windowStyle(.titleBar)
+        // Airlock's onboarding makes the window transparent and hides the
+        // traffic-light buttons, but the title bar itself stays put unless the
+        // window has no titled chrome — otherwise the bar and app title float
+        // over the intro card. `.hiddenTitleBar` is the configuration Airlock
+        // documents; the workspace's toolbar still renders in the title area.
+        .windowStyle(.hiddenTitleBar)
         .defaultSize(width: 1220, height: 820)
 
         Settings {

--- a/Sources/App/LoginItemController.swift
+++ b/Sources/App/LoginItemController.swift
@@ -1,0 +1,49 @@
+// Copyright 2026 Alejandro Modroño Vara <amodrono@alu.icai.comillas.edu>
+//
+// Licensed under the Apache License, Version 2.0.
+// You may obtain a copy of the License in the LICENSE file at the root of this repository.
+
+import Foundation
+import ServiceManagement
+import OSLog
+
+/// Wraps `SMAppService.mainApp` so the Settings "Launch at login" toggle
+/// actually registers the app as a login item instead of just toggling a
+/// UserDefaults bool that nothing reads.
+@MainActor
+final class LoginItemController: ObservableObject {
+    @Published private(set) var isEnabled: Bool = false
+    @Published private(set) var lastError: String?
+
+    private let logger = Logger(subsystem: "es.amodrono.foodle", category: "LoginItem")
+
+    init() {
+        refresh()
+    }
+
+    /// Re-read the actual SMAppService state so the UI reflects reality.
+    func refresh() {
+        // The system can decide to disable login items behind our back
+        // (System Settings > General > Login Items), so the source of
+        // truth is SMAppService.mainApp.status, not anything we cached.
+        isEnabled = SMAppService.mainApp.status == .enabled
+    }
+
+    /// Attempt to register or unregister the app as a login item. Reflects
+    /// the actual resulting state back into `isEnabled` so the UI doesn't
+    /// show "on" when the system rejected the registration.
+    func setEnabled(_ desired: Bool) {
+        lastError = nil
+        do {
+            if desired {
+                try SMAppService.mainApp.register()
+            } else {
+                try SMAppService.mainApp.unregister()
+            }
+        } catch {
+            logger.error("SMAppService \(desired ? "register" : "unregister") failed: \(error.localizedDescription, privacy: .public)")
+            lastError = error.localizedDescription
+        }
+        refresh()
+    }
+}

--- a/Sources/App/Services/SpotlightIndexer.swift
+++ b/Sources/App/Services/SpotlightIndexer.swift
@@ -12,21 +12,28 @@ import OSLog
 /// Indexes Moodle courses and files into CoreSpotlight for system-wide search.
 final class SpotlightIndexer: @unchecked Sendable {
     private static let domainPrefix = BundleIdentifiers.spotlightPrefix
+    private static let lastIndexedDomainsKey = "spotlightLastIndexedDomains"
     private let logger = Logger(subsystem: "es.amodrono.foodle", category: "SpotlightIndexer")
 
     static let shared = SpotlightIndexer()
 
     private init() {}
 
+    private static func domainIdentifier(siteID: String, courseID: Int) -> String {
+        "\(domainPrefix).course.\(siteID).\(courseID)"
+    }
+
     // MARK: - Index After Sync
 
     func indexCourses(_ courses: [MoodleCourse], items: [LocalItem], siteName: String) {
         var searchableItems: [CSSearchableItem] = []
+        var currentDomains = Set<String>()
 
         let itemsByCourseID = Dictionary(grouping: items, by: \.courseID)
 
         for course in courses where course.isSyncEnabled {
             searchableItems.append(makeSearchableItem(from: course, siteName: siteName))
+            currentDomains.insert(Self.domainIdentifier(siteID: course.siteID, courseID: course.id))
 
             if let courseItems = itemsByCourseID[course.id] {
                 for item in courseItems where !item.isDirectory {
@@ -37,16 +44,51 @@ final class SpotlightIndexer: @unchecked Sendable {
             }
         }
 
-        guard !searchableItems.isEmpty else { return }
+        // Remove Spotlight entries for any course that was indexed previously
+        // but is no longer enrolled or no longer has sync enabled. Without
+        // this, dropped courses linger in Spotlight forever and clicking the
+        // stale result deep-links to a course AppState no longer knows about.
+        removeOrphans(currentDomains: currentDomains)
+
+        guard !searchableItems.isEmpty else {
+            persistIndexedDomains(currentDomains)
+            return
+        }
 
         let count = searchableItems.count
-        CSSearchableIndex.default().indexSearchableItems(searchableItems) { [logger] error in
+        let snapshot = currentDomains
+        CSSearchableIndex.default().indexSearchableItems(searchableItems) { [logger, weak self] error in
             if let error {
                 logger.error("Spotlight indexing failed: \(error.localizedDescription, privacy: .public)")
             } else {
                 logger.info("Indexed \(count) items in Spotlight")
+                self?.persistIndexedDomains(snapshot)
             }
         }
+    }
+
+    private func removeOrphans(currentDomains: Set<String>) {
+        let previous = loadIndexedDomains()
+        let orphans = previous.subtracting(currentDomains)
+        guard !orphans.isEmpty else { return }
+
+        let orphanList = Array(orphans)
+        CSSearchableIndex.default().deleteSearchableItems(withDomainIdentifiers: orphanList) { [logger] error in
+            if let error {
+                logger.error("Failed to remove orphaned Spotlight domains: \(error.localizedDescription, privacy: .public)")
+            } else {
+                logger.info("Removed \(orphanList.count) orphaned Spotlight course domain(s)")
+            }
+        }
+    }
+
+    private func loadIndexedDomains() -> Set<String> {
+        let raw = UserDefaults.standard.stringArray(forKey: Self.lastIndexedDomainsKey) ?? []
+        return Set(raw)
+    }
+
+    private func persistIndexedDomains(_ domains: Set<String>) {
+        UserDefaults.standard.set(Array(domains), forKey: Self.lastIndexedDomainsKey)
     }
 
     // MARK: - Remove
@@ -59,15 +101,23 @@ final class SpotlightIndexer: @unchecked Sendable {
                 logger.info("Cleared Spotlight index")
             }
         }
+        // Wipe the snapshot so the next indexCourses call doesn't think there
+        // are orphans to delete from an empty index.
+        UserDefaults.standard.removeObject(forKey: Self.lastIndexedDomainsKey)
     }
 
     func removeItems(forCourse courseID: Int, siteID: String) {
-        let groupID = "\(Self.domainPrefix).course.\(siteID).\(courseID)"
+        let groupID = Self.domainIdentifier(siteID: siteID, courseID: courseID)
         CSSearchableIndex.default().deleteSearchableItems(withDomainIdentifiers: [groupID]) { [logger] error in
             if let error {
                 logger.error("Failed to remove Spotlight items for course \(courseID): \(error.localizedDescription, privacy: .public)")
             }
         }
+        // Forget this course from the snapshot so it isn't double-removed
+        // as an orphan on the next indexCourses pass.
+        var snapshot = loadIndexedDomains()
+        snapshot.remove(groupID)
+        persistIndexedDomains(snapshot)
     }
 
     // MARK: - Item Construction
@@ -82,11 +132,10 @@ final class SpotlightIndexer: @unchecked Sendable {
         if let end = course.endDate { attributes.endDate = end }
         attributes.keywords = [course.shortName, siteName, "Moodle", "course"]
 
-        let uniqueID = "\(Self.domainPrefix).course.\(course.siteID).\(course.id)"
-        let domainID = "\(Self.domainPrefix).course.\(course.siteID).\(course.id)"
+        let domainID = Self.domainIdentifier(siteID: course.siteID, courseID: course.id)
 
         return CSSearchableItem(
-            uniqueIdentifier: uniqueID,
+            uniqueIdentifier: domainID,
             domainIdentifier: domainID,
             attributeSet: attributes
         )
@@ -115,7 +164,7 @@ final class SpotlightIndexer: @unchecked Sendable {
         if let mimeType = item.contentType { attributes.contentType = mimeType }
 
         let uniqueID = "\(Self.domainPrefix).item.\(item.id)"
-        let domainID = "\(Self.domainPrefix).course.\(item.siteID).\(item.courseID)"
+        let domainID = Self.domainIdentifier(siteID: item.siteID, courseID: item.courseID)
 
         return CSSearchableItem(
             uniqueIdentifier: uniqueID,

--- a/Sources/App/UpdateController.swift
+++ b/Sources/App/UpdateController.swift
@@ -7,17 +7,22 @@ import Sparkle
 
 @MainActor
 final class UpdateController: ObservableObject {
+    // SPUStandardUpdaterController owns the user driver that drives Sparkle's
+    // update UI. Discarding it (storing only `updater`) invalidates the driver
+    // and update prompts silently no-op, so retain it for the lifetime of the
+    // controller.
+    private let updaterController: SPUStandardUpdaterController
     let updater: SPUUpdater
 
     @Published var canCheckForUpdates = false
 
     init() {
-        let controller = SPUStandardUpdaterController(
+        self.updaterController = SPUStandardUpdaterController(
             startingUpdater: true,
             updaterDelegate: nil,
             userDriverDelegate: nil
         )
-        updater = controller.updater
+        self.updater = updaterController.updater
 
         updater.publisher(for: \.canCheckForUpdates)
             .assign(to: &$canCheckForUpdates)

--- a/Sources/App/ViewModels/AppState.swift
+++ b/Sources/App/ViewModels/AppState.swift
@@ -37,6 +37,7 @@ final class AppState: ObservableObject {
     private var isLoadingCourses = false
     private var validatedSitesByURL: [String: MoodleSite] = [:]
     private var automaticSyncTask: Task<Void, Never>?
+    private var lastAppliedSyncInterval: Double = -1
     private var sessionBootstrapTask: Task<Void, Error>?
     private var syncSettingsObserver: NSObjectProtocol?
     private let logger = Logger(subsystem: "es.amodrono.foodle", category: "AppState")
@@ -1046,13 +1047,20 @@ final class AppState: ObservableObject {
     }
 
     private func observeSyncSettings() {
+        // UserDefaults.didChangeNotification fires on every defaults write
+        // across the app (launch counters, prompt state, etc.), so check
+        // whether the value we actually care about changed before tearing
+        // down and recreating the sync task.
         syncSettingsObserver = NotificationCenter.default.addObserver(
             forName: UserDefaults.didChangeNotification,
             object: nil,
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor in
-                self?.refreshAutomaticSyncSchedule()
+                guard let self else { return }
+                let currentInterval = self.userDefaults.double(forKey: Self.syncIntervalMinutesKey)
+                guard currentInterval != self.lastAppliedSyncInterval else { return }
+                self.refreshAutomaticSyncSchedule()
             }
         }
     }
@@ -1061,9 +1069,16 @@ final class AppState: ObservableObject {
         automaticSyncTask?.cancel()
         automaticSyncTask = nil
 
-        guard currentSite != nil, currentToken != nil, syncEngine != nil else { return }
+        guard currentSite != nil, currentToken != nil, syncEngine != nil else {
+            lastAppliedSyncInterval = -1
+            return
+        }
 
-        let intervalMinutes = userDefaults.double(forKey: Self.syncIntervalMinutesKey)
+        let rawInterval = userDefaults.double(forKey: Self.syncIntervalMinutesKey)
+        // Clamp to a sane positive range so a corrupt or maliciously edited
+        // preference can't overflow UInt64 in the nanosecond conversion.
+        let intervalMinutes = max(0, min(rawInterval, 24 * 60))
+        lastAppliedSyncInterval = intervalMinutes
         guard intervalMinutes > 0 else { return }
 
         let intervalNanoseconds = UInt64(intervalMinutes * 60 * 1_000_000_000)

--- a/Sources/App/ViewModels/AppState.swift
+++ b/Sources/App/ViewModels/AppState.swift
@@ -8,6 +8,7 @@ import SwiftUI
 import AuthenticationServices
 import AppKit
 import CoreSpotlight
+import UserNotifications
 import SharedDomain
 import FoodleNetworking
 import FoodlePersistence
@@ -26,6 +27,12 @@ final class AppState: ObservableObject {
     @Published var syncStatus: SyncStatus = .idle
     @Published var lastSyncDate: Date?
     @Published var errorMessage: String?
+    /// Set when a sync/load failed because the session is no longer valid.
+    /// The workspace surfaces a reconnect prompt rather than a generic error.
+    @Published var sessionExpired = false
+    /// Fine-grained progress for the in-flight "sync all" pass, shown in the
+    /// workspace. Only meaningful while `syncStatus` is `.syncing`.
+    @Published var syncProgressDetail: SyncProgressDetail?
 
     private let moodleClient = MoodleClient()
     private var database: Database?
@@ -60,6 +67,13 @@ final class AppState: ObservableObject {
         case syncing(progress: Double)
         case completed
         case error(String)
+    }
+
+    /// Per-course progress for a "sync all" pass.
+    struct SyncProgressDetail: Equatable {
+        var completed: Int
+        var total: Int
+        var courseName: String
     }
 
     private static let syncOnLaunchKey = "syncOnLaunch"
@@ -579,6 +593,9 @@ final class AppState: ObservableObject {
             courses = try database?.fetchCourses(siteID: site.id) ?? remoteCourses
             reloadCourseTags()
             logger.info("Loaded \(self.courses.count) courses")
+        } catch let error as FoodleError where error.requiresReauthentication {
+            logger.error("Failed to load courses: session expired")
+            handleSessionExpired()
         } catch {
             logger.error("Failed to load courses: \(error.localizedDescription, privacy: .public)")
             errorMessage = error.localizedDescription
@@ -706,24 +723,60 @@ final class AppState: ObservableObject {
     func syncAll() async {
         guard let site = currentSite, let token = currentToken, let engine = syncEngine else { return }
 
+        errorMessage = nil
         syncStatus = .syncing(progress: 0)
 
         let enabledCourses = courses.filter(\.isSyncEnabled)
-        await engine.syncAllCourses(site: site, token: token, courses: enabledCourses)
+        syncProgressDetail = enabledCourses.isEmpty
+            ? nil
+            : SyncProgressDetail(completed: 0, total: enabledCourses.count, courseName: enabledCourses[0].shortName)
 
-        syncStatus = .completed
-        lastSyncDate = Date()
+        // Poll the engine for per-course progress while the sync runs so the
+        // workspace can show "syncing X of Y".
+        let progressTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                let progress = await engine.allProgress()
+                let completed = enabledCourses.filter { (progress[$0.id]?.state ?? .syncing) != .syncing }.count
+                let current = enabledCourses.first { (progress[$0.id]?.state ?? .syncing) == .syncing }
+                self.syncProgressDetail = SyncProgressDetail(
+                    completed: completed,
+                    total: enabledCourses.count,
+                    courseName: current?.shortName ?? ""
+                )
+                self.syncStatus = .syncing(
+                    progress: enabledCourses.isEmpty ? 1 : Double(completed) / Double(enabledCourses.count)
+                )
+                try? await Task.sleep(for: .milliseconds(300))
+            }
+        }
+        defer { syncProgressDetail = nil }
 
-        // Signal the File Provider to refresh
-        signalFileProviderChanges()
-
-        // Update Spotlight index
-        indexForSpotlight()
+        do {
+            try await engine.syncAllCourses(site: site, token: token, courses: enabledCourses)
+            progressTask.cancel()
+            syncStatus = .completed
+            lastSyncDate = Date()
+            signalFileProviderChanges()
+            indexForSpotlight()
+            notifySyncCompletedIfEnabled(courseCount: enabledCourses.count)
+        } catch let error as FoodleError where error.requiresReauthentication {
+            progressTask.cancel()
+            handleSessionExpired()
+        } catch is CancellationError {
+            progressTask.cancel()
+            syncStatus = .idle
+        } catch {
+            progressTask.cancel()
+            syncStatus = .error(error.localizedDescription)
+            errorMessage = error.localizedDescription
+        }
     }
 
     func syncCourse(_ course: MoodleCourse) async {
         guard let site = currentSite, let token = currentToken, let engine = syncEngine else { return }
 
+        errorMessage = nil
         syncStatus = .syncing(progress: 0)
 
         do {
@@ -731,9 +784,72 @@ final class AppState: ObservableObject {
             syncStatus = .completed
             lastSyncDate = Date()
             signalFileProviderChanges()
+        } catch let error as FoodleError where error.requiresReauthentication {
+            handleSessionExpired()
+        } catch is CancellationError {
+            syncStatus = .idle
         } catch {
             syncStatus = .error(error.localizedDescription)
             errorMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: - Session Recovery
+
+    /// Called when a sync or load fails because the session is no longer valid.
+    /// Surfaces a reconnect prompt and stops the automatic sync loop so we don't
+    /// keep hammering the server with a dead token.
+    private func handleSessionExpired() {
+        logger.warning("Session expired — prompting user to reconnect")
+        sessionExpired = true
+        syncStatus = .error(FoodleError.tokenExpired.localizedDescription)
+        automaticSyncTask?.cancel()
+        automaticSyncTask = nil
+        lastAppliedSyncInterval = -1
+    }
+
+    /// Sign out and return to onboarding so the user can authenticate again.
+    func reconnect() async {
+        sessionExpired = false
+        await logout()
+    }
+
+    /// Clear a surfaced error banner.
+    func dismissError() {
+        errorMessage = nil
+        if case .error = syncStatus {
+            syncStatus = lastSyncDate == nil ? .idle : .completed
+        }
+    }
+
+    // MARK: - Notifications
+
+    private func notifySyncCompletedIfEnabled(courseCount: Int) {
+        guard userDefaults.bool(forKey: "notifyOnSyncComplete") else { return }
+
+        Task {
+            let center = UNUserNotificationCenter.current()
+            let settings = await center.notificationSettings()
+
+            var authorized = settings.authorizationStatus == .authorized
+            if settings.authorizationStatus == .notDetermined {
+                authorized = (try? await center.requestAuthorization(options: [.alert, .sound])) ?? false
+            }
+            guard authorized else { return }
+
+            let content = UNMutableNotificationContent()
+            content.title = "Sync complete"
+            content.body = courseCount == 1
+                ? "1 course is up to date."
+                : "\(courseCount) courses are up to date."
+            content.sound = .default
+
+            let request = UNNotificationRequest(
+                identifier: UUID().uuidString,
+                content: content,
+                trigger: nil
+            )
+            try? await center.add(request)
         }
     }
 
@@ -1001,6 +1117,10 @@ final class AppState: ObservableObject {
             } else {
                 await self.ensureFileProviderDomain(site: site)
             }
+
+            // Clear any downloads left mid-flight by a previous run so they
+            // don't appear stuck in-progress.
+            try? self.database?.resetStaleDownloads(siteID: site.id)
 
             try Task.checkCancellation()
             await self.resolveFileProviderAuthentication(for: site)

--- a/Sources/App/Views/ContentView.swift
+++ b/Sources/App/Views/ContentView.swift
@@ -9,6 +9,14 @@ import WhatsNewKit
 struct ContentView: View {
     @EnvironmentObject var appState: AppState
 
+    // Build the environment once per ContentView instance instead of on every
+    // body re-evaluation. Avoids spinning up a fresh UserDefaultsWhatsNewVersionStore
+    // and re-constructing the collection on every state change.
+    @State private var whatsNewEnvironment = WhatsNewEnvironment(
+        versionStore: UserDefaultsWhatsNewVersionStore(),
+        whatsNewCollection: WhatsNewProvider.makeCollection()
+    )
+
     var body: some View {
         Group {
             switch appState.currentScreen {
@@ -16,13 +24,7 @@ struct ContentView: View {
                 OnboardingView()
             case .workspace:
                 WorkspaceView()
-                    .environment(
-                        \.whatsNew,
-                        WhatsNewEnvironment(
-                            versionStore: UserDefaultsWhatsNewVersionStore(),
-                            whatsNewCollection: WhatsNewProvider.collection
-                        )
-                    )
+                    .environment(\.whatsNew, whatsNewEnvironment)
                     .whatsNewSheet()
                     .supportPrompt()
             }

--- a/Sources/App/Views/Courses/CourseDetailView.swift
+++ b/Sources/App/Views/Courses/CourseDetailView.swift
@@ -60,8 +60,6 @@ struct CourseDetailView: View {
                     TextField(course.sanitizedFolderName, text: $customFolderName)
                         .textFieldStyle(.roundedBorder)
                         .onSubmit { saveFolderName() }
-                        // Save when the user clicks away without pressing Return.
-                        .onChange(of: course.id) { _, _ in saveFolderName() }
 
                     if customFolderName.isEmpty {
                         Text("Defaults to \(course.sanitizedFolderName)")

--- a/Sources/App/Views/Courses/CourseDetailView.swift
+++ b/Sources/App/Views/Courses/CourseDetailView.swift
@@ -60,6 +60,8 @@ struct CourseDetailView: View {
                     TextField(course.sanitizedFolderName, text: $customFolderName)
                         .textFieldStyle(.roundedBorder)
                         .onSubmit { saveFolderName() }
+                        // Save when the user clicks away without pressing Return.
+                        .onChange(of: course.id) { _, _ in saveFolderName() }
 
                     if customFolderName.isEmpty {
                         Text("Defaults to \(course.sanitizedFolderName)")
@@ -102,7 +104,13 @@ struct CourseDetailView: View {
 
             Section("Sync") {
                 Toggle("Sync this course", isOn: $localSyncEnabled)
-                    .onChange(of: localSyncEnabled) { _, newValue in
+                    .onChange(of: localSyncEnabled) { oldValue, newValue in
+                        // Skip when the change comes from loadCustomization()
+                        // re-syncing the @State from the course model. Without
+                        // this guard, switching between courses re-applies the
+                        // same value and can trigger a redundant File Provider
+                        // signal that wipes recently-discovered items.
+                        guard oldValue != newValue, newValue != course.isSyncEnabled else { return }
                         appState.setCourseSyncEnabled(newValue, for: course)
                     }
 

--- a/Sources/App/Views/MenuBar/MenuBarView.swift
+++ b/Sources/App/Views/MenuBar/MenuBarView.swift
@@ -46,7 +46,14 @@ struct MenuBarView: View {
             case .syncing:
                 Text("Syncing…")
             case .error:
-                Text("Sync error")
+                if appState.sessionExpired {
+                    Text("Session expired — open Findle to reconnect")
+                } else if let message = appState.errorMessage {
+                    Text(message)
+                        .lineLimit(2)
+                } else {
+                    Text("Sync error")
+                }
             default:
                 if let date = appState.lastSyncDate {
                     Text("Last synced \(date, format: .relative(presentation: .named))")

--- a/Sources/App/Views/Onboarding/OnboardingView.swift
+++ b/Sources/App/Views/Onboarding/OnboardingView.swift
@@ -31,7 +31,7 @@ struct OnboardingView: View {
                         NSApplication.shared.terminate(nil)
                     }
                 },
-                immersiveIntroOnly: true
+                hidesOtherAppsDuringIntro: true
             )
         )
         .environmentObject(onboardingState)

--- a/Sources/App/Views/Onboarding/Steps/SignInStepView.swift
+++ b/Sources/App/Views/Onboarding/Steps/SignInStepView.swift
@@ -137,11 +137,22 @@ struct SignInStepView: View {
     private func signInWithPassword() async {
         guard let site else { return }
 
+        // Trim whitespace from username — auto-capitalising or copy/paste
+        // commonly leaves a leading space and Moodle returns an opaque
+        // "invalid credentials" error instead of a useful hint. Leave the
+        // password untouched: trailing whitespace there may be intentional.
+        let trimmedUsername = onboardingState.username.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedUsername.isEmpty else {
+            onboardingState.errorMessage = "Username is required."
+            updateCredentialsEnabled()
+            return
+        }
+
         onboardingState.errorMessage = nil
         navigator?.setContinueEnabled(false)
 
         do {
-            try await appState.signInAndPersist(site: site, username: onboardingState.username, password: onboardingState.password)
+            try await appState.signInAndPersist(site: site, username: trimmedUsername, password: onboardingState.password)
             signInCompleted = true
             navigator?.resetButton()
             navigator?.setContinueEnabled(true)

--- a/Sources/App/Views/Settings/SettingsView.swift
+++ b/Sources/App/Views/Settings/SettingsView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 struct SettingsView: View {
     @EnvironmentObject private var appState: AppState
     @EnvironmentObject private var updateController: UpdateController
-    @AppStorage("launchAtLogin") private var launchAtLogin = false
+    @StateObject private var loginItem = LoginItemController()
     @AppStorage("showMenuBarIcon") private var showMenuBarIcon = true
     @AppStorage("notifyOnSyncComplete") private var notifyOnSyncComplete = false
     @AppStorage("syncIntervalMinutes") private var syncInterval: Double = 30
@@ -21,7 +21,22 @@ struct SettingsView: View {
     var body: some View {
         Form {
             Section("General") {
-                Toggle("Launch Findle at login", isOn: $launchAtLogin)
+                Toggle(
+                    "Launch Findle at login",
+                    // Drive the toggle from SMAppService.mainApp.status so the
+                    // UI shows the actual registration state — the system can
+                    // disable login items behind our back, and a stale
+                    // UserDefaults bool would lie to the user.
+                    isOn: Binding(
+                        get: { loginItem.isEnabled },
+                        set: { loginItem.setEnabled($0) }
+                    )
+                )
+                if let error = loginItem.lastError {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
                 Toggle("Show in menu bar", isOn: $showMenuBarIcon)
                 Toggle(
                     "Automatically check for updates",
@@ -143,5 +158,10 @@ struct SettingsView: View {
         .formStyle(.grouped)
         .navigationTitle("Settings")
         .frame(minWidth: 480, idealWidth: 520)
+        .onAppear {
+            // System Settings > Login Items can flip our registration state
+            // without notifying us, so re-read it whenever Settings reopens.
+            loginItem.refresh()
+        }
     }
 }

--- a/Sources/App/Views/WhatsNew/WhatsNewProvider.swift
+++ b/Sources/App/Views/WhatsNew/WhatsNewProvider.swift
@@ -7,50 +7,59 @@ import SwiftUI
 import WhatsNewKit
 
 /// Central registry of all What's New entries shown after app updates.
+///
+/// The collection is built on demand on the MainActor instead of being a
+/// global static. WhatsNewKit's value types embed SwiftUI `Color`s, which
+/// historically required the previous `nonisolated(unsafe)` annotation to
+/// silence Swift 6 strict concurrency. Building it on demand keeps the
+/// SwiftUI types on the only actor that's allowed to touch them.
 enum WhatsNewProvider {
-    nonisolated(unsafe) static let collection: WhatsNewCollection = [
-        WhatsNew(
-            version: "0.1.2",
-            title: "What's New in Findle",
-            features: [
-                WhatsNew.Feature(
-                    image: .init(
-                        systemName: "folder.fill",
-                        foregroundColor: .accentColor
+    @MainActor
+    static func makeCollection() -> WhatsNewCollection {
+        [
+            WhatsNew(
+                version: "0.1.2",
+                title: "What's New in Findle",
+                features: [
+                    WhatsNew.Feature(
+                        image: .init(
+                            systemName: "folder.fill",
+                            foregroundColor: .accentColor
+                        ),
+                        title: "Your Courses in Finder",
+                        subtitle: "Browse and open Moodle files directly from the Finder sidebar — no browser needed."
                     ),
-                    title: "Your Courses in Finder",
-                    subtitle: "Browse and open Moodle files directly from the Finder sidebar — no browser needed."
-                ),
-                WhatsNew.Feature(
-                    image: .init(
-                        systemName: "arrow.down.circle.fill",
-                        foregroundColor: .green
+                    WhatsNew.Feature(
+                        image: .init(
+                            systemName: "arrow.down.circle.fill",
+                            foregroundColor: .green
+                        ),
+                        title: "On-Demand Downloads",
+                        subtitle: "Files download only when you open them and can be evicted to save disk space."
                     ),
-                    title: "On-Demand Downloads",
-                    subtitle: "Files download only when you open them and can be evicted to save disk space."
-                ),
-                WhatsNew.Feature(
-                    image: .init(
-                        systemName: "lock.shield.fill",
-                        foregroundColor: .orange
+                    WhatsNew.Feature(
+                        image: .init(
+                            systemName: "lock.shield.fill",
+                            foregroundColor: .orange
+                        ),
+                        title: "SSO & Direct Login",
+                        subtitle: "Sign in with your university's SSO provider or with username and password."
                     ),
-                    title: "SSO & Direct Login",
-                    subtitle: "Sign in with your university's SSO provider or with username and password."
-                ),
-                WhatsNew.Feature(
-                    image: .init(
-                        systemName: "doc.badge.plus",
-                        foregroundColor: .purple
-                    ),
-                    title: "Local Files",
-                    subtitle: "Create your own notes and files alongside course content — they stay local and never sync."
+                    WhatsNew.Feature(
+                        image: .init(
+                            systemName: "doc.badge.plus",
+                            foregroundColor: .purple
+                        ),
+                        title: "Local Files",
+                        subtitle: "Create your own notes and files alongside course content — they stay local and never sync."
+                    )
+                ],
+                primaryAction: WhatsNew.PrimaryAction(
+                    title: "Continue",
+                    backgroundColor: .accentColor,
+                    foregroundColor: .white
                 )
-            ],
-            primaryAction: WhatsNew.PrimaryAction(
-                title: "Continue",
-                backgroundColor: .accentColor,
-                foregroundColor: .white
             )
-        )
-    ]
+        ]
+    }
 }

--- a/Sources/App/Views/Workspace/SupportPrompt.swift
+++ b/Sources/App/Views/Workspace/SupportPrompt.swift
@@ -8,18 +8,32 @@ import SwiftUI
 /// Occasional prompt asking users to support the project.
 struct SupportPrompt: ViewModifier {
     private static let launchCountKey = "supportPromptLaunchCount"
+    private static let lastShownLaunchKey = "supportPromptLastShownLaunch"
     private static let minLaunches = 5
+    private static let minLaunchesBetweenPrompts = 10
     private static let showProbability = 0.3
 
     @AppStorage(SupportPrompt.launchCountKey) private var launchCount = 0
+    @AppStorage(SupportPrompt.lastShownLaunchKey) private var lastShownLaunch = 0
+    @State private var hasEvaluatedThisAppearance = false
     @State private var showAlert = false
 
     func body(content: Content) -> some View {
         content
             .onAppear {
+                // The view modifier's onAppear fires every time the view
+                // re-appears (tab switch, window reactivation, etc.). Only
+                // evaluate the gate once per process so the user can't see
+                // the alert multiple times in a single session.
+                guard !hasEvaluatedThisAppearance else { return }
+                hasEvaluatedThisAppearance = true
+
                 launchCount += 1
+                let launchesSinceLastShown = launchCount - lastShownLaunch
                 guard launchCount >= Self.minLaunches,
+                      launchesSinceLastShown >= Self.minLaunchesBetweenPrompts,
                       Double.random(in: 0...1) < Self.showProbability else { return }
+                lastShownLaunch = launchCount
                 showAlert = true
             }
             .alert("Enjoying Findle?", isPresented: $showAlert) {

--- a/Sources/App/Views/Workspace/WorkspaceView.swift
+++ b/Sources/App/Views/Workspace/WorkspaceView.swift
@@ -111,6 +111,61 @@ struct WorkspaceView: View {
                 await appState.loadCourses()
             }
         }
+        .safeAreaInset(edge: .top, spacing: 0) {
+            banners
+        }
+    }
+
+    // MARK: - Banners
+
+    @ViewBuilder
+    private var banners: some View {
+        VStack(spacing: 0) {
+            if appState.sessionExpired {
+                bannerBar(
+                    icon: "person.crop.circle.badge.exclamationmark",
+                    tint: .orange,
+                    message: "Your session has expired. Reconnect to keep syncing.",
+                    actionTitle: "Reconnect"
+                ) {
+                    Task { await appState.reconnect() }
+                }
+            } else if let error = appState.errorMessage {
+                bannerBar(
+                    icon: "exclamationmark.triangle.fill",
+                    tint: .red,
+                    message: error,
+                    actionTitle: "Dismiss"
+                ) {
+                    appState.dismissError()
+                }
+            }
+        }
+    }
+
+    private func bannerBar(
+        icon: String,
+        tint: Color,
+        message: String,
+        actionTitle: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+                .foregroundStyle(tint)
+            Text(message)
+                .lineLimit(2)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Button(actionTitle, action: action)
+                .buttonStyle(.borderless)
+        }
+        .font(.callout)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background(tint.opacity(0.12))
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
     }
 
     // MARK: - Sidebar
@@ -216,7 +271,11 @@ struct WorkspaceView: View {
             case .syncing:
                 ProgressView()
                     .controlSize(.small)
-                Text("Syncing…")
+                if let detail = appState.syncProgressDetail, detail.total > 0 {
+                    Text("Syncing \(min(detail.completed + 1, detail.total)) of \(detail.total)…")
+                } else {
+                    Text("Syncing…")
+                }
             case .completed:
                 if let date = appState.lastSyncDate {
                     Image(systemName: "checkmark.circle.fill")

--- a/Sources/FileProviderExtension/FileDownloader.swift
+++ b/Sources/FileProviderExtension/FileDownloader.swift
@@ -8,11 +8,24 @@ import FileProvider
 import SharedDomain
 import FoodleNetworking
 import FoodlePersistence
+import OSLog
 
 /// Handles file downloads for the File Provider extension.
 /// Uses URLSession's callback API so File Provider completion handlers stay in the
 /// framework's callback world instead of crossing Swift concurrency executors.
 enum FileDownloader {
+    private static let logger = Logger(subsystem: "es.amodrono.foodle.file-provider", category: "Download")
+
+    /// Reset an item to `.placeholder` after a failed download so the next
+    /// fetch retries cleanly. A failure here would otherwise strand the item in
+    /// `.downloading`, so log it instead of swallowing it silently.
+    private static func resetToPlaceholder(itemID: String, database: Database) {
+        do {
+            try database.updateItemSyncState(id: itemID, state: .placeholder)
+        } catch {
+            logger.error("Failed to reset \(itemID, privacy: .public) to placeholder after download failure: \(error.localizedDescription, privacy: .public)")
+        }
+    }
     static func startDownload(
         item: LocalItem,
         database: Database,
@@ -46,7 +59,7 @@ enum FileDownloader {
 
         let task = URLSession.shared.downloadTask(with: authenticatedRequest) { downloadedURL, response, error in
             if let error {
-                try? database.updateItemSyncState(id: item.id, state: .placeholder)
+                resetToPlaceholder(itemID: item.id, database: database)
                 completionBridge.fail(error)
                 return
             }
@@ -54,7 +67,7 @@ enum FileDownloader {
             guard let downloadedURL,
                   let httpResponse = response as? HTTPURLResponse,
                   (200...299).contains(httpResponse.statusCode) else {
-                try? database.updateItemSyncState(id: item.id, state: .placeholder)
+                resetToPlaceholder(itemID: item.id, database: database)
                 completionBridge.fail(FoodleError.downloadFailed(itemID: item.id, reason: "Download failed"))
                 return
             }
@@ -78,7 +91,7 @@ enum FileDownloader {
                     item: FileProviderItem(localItem: updatedItem)
                 )
             } catch {
-                try? database.updateItemSyncState(id: item.id, state: .placeholder)
+                resetToPlaceholder(itemID: item.id, database: database)
                 completionBridge.fail(error)
             }
         }

--- a/Sources/FileProviderExtension/FileDownloader.swift
+++ b/Sources/FileProviderExtension/FileDownloader.swift
@@ -33,22 +33,18 @@ enum FileDownloader {
             throw FoodleError.authenticationRequired
         }
 
-        guard var components = URLComponents(url: remoteURL, resolvingAgainstBaseURL: false) else {
-            throw FoodleError.downloadFailed(itemID: item.id, reason: "Could not construct download URL")
-        }
-
-        var queryItems = components.queryItems ?? []
-        queryItems.append(URLQueryItem(name: "token", value: tokenString))
-        components.queryItems = queryItems
-
-        guard let authenticatedURL = components.url else {
-            throw FoodleError.downloadFailed(itemID: item.id, reason: "Could not construct download URL")
-        }
+        // Send the token in the POST body instead of the URL query so it
+        // doesn't leak into URLSession metrics, the Referer header on CDN
+        // redirects, or crash reports that include the in-flight URL.
+        var authenticatedRequest = URLRequest(url: remoteURL)
+        authenticatedRequest.httpMethod = "POST"
+        authenticatedRequest.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        authenticatedRequest.httpBody = formEncodeToken(tokenString)
 
         let destinationURL = makeTemporaryDestinationURL(for: item)
         try database.updateItemSyncState(id: item.id, state: .downloading)
 
-        let task = URLSession.shared.downloadTask(with: URLRequest(url: authenticatedURL)) { downloadedURL, response, error in
+        let task = URLSession.shared.downloadTask(with: authenticatedRequest) { downloadedURL, response, error in
             if let error {
                 try? database.updateItemSyncState(id: item.id, state: .placeholder)
                 completionBridge.fail(error)
@@ -91,6 +87,16 @@ enum FileDownloader {
             task.cancel()
         }
         task.resume()
+    }
+
+    /// Form-encode just the token value for the download body. Using a
+    /// restrictive allowed set avoids any chance that a token containing
+    /// `+`, `&`, or `=` confuses Moodle's POST parser on the receiving side.
+    private static func formEncodeToken(_ token: String) -> Data? {
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")
+        let encoded = token.addingPercentEncoding(withAllowedCharacters: allowed) ?? token
+        return "token=\(encoded)".data(using: .utf8)
     }
 
     private static func makeTemporaryDestinationURL(for item: LocalItem) -> URL {

--- a/Sources/FileProviderExtension/FileProviderExtension.swift
+++ b/Sources/FileProviderExtension/FileProviderExtension.swift
@@ -333,70 +333,103 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
             return Progress()
         }
 
-        guard var localItem = try? db.fetchItem(id: item.itemIdentifier.rawValue) else {
+        let itemID = item.itemIdentifier.rawValue
+
+        guard let localItem = try? db.fetchItem(id: itemID) else {
             completionHandler(nil, [], false, NSFileProviderError(.noSuchItem))
             return Progress()
         }
 
-        // Only allow modifications to local items.
-        guard localItem.isLocal else {
-            completionHandler(nil, [], false, NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError))
+        // Local items: full edits allowed (rename, move, content, tags).
+        if localItem.isLocal {
+            do {
+                var newFilename = localItem.filename
+                var newParentID = localItem.parentID
+                var newLocalPath = localItem.localPath
+                var newFileSize = localItem.fileSize
+                var newTagData = localItem.tagData
+
+                if changedFields.contains(.filename) {
+                    newFilename = item.filename
+                }
+                if changedFields.contains(.parentItemIdentifier) {
+                    newParentID = item.parentItemIdentifier == .rootContainer ? nil : item.parentItemIdentifier.rawValue
+                }
+                if changedFields.contains(.contents), let newContents {
+                    let dest = try localContentURL(itemID: localItem.id)
+                    try? FileManager.default.removeItem(at: dest)
+                    try FileManager.default.copyItem(at: newContents, to: dest)
+                    newLocalPath = dest.path
+                    let attrs = try? FileManager.default.attributesOfItem(atPath: dest.path)
+                    newFileSize = (attrs?[.size] as? Int64) ?? 0
+                }
+                if changedFields.contains(.tagData) {
+                    newTagData = item.tagData ?? nil
+                }
+
+                let updated = LocalItem(
+                    id: localItem.id,
+                    parentID: newParentID,
+                    siteID: localItem.siteID,
+                    courseID: localItem.courseID,
+                    remoteID: localItem.remoteID,
+                    filename: newFilename,
+                    isDirectory: localItem.isDirectory,
+                    contentType: localItem.contentType,
+                    fileSize: newFileSize,
+                    creationDate: localItem.creationDate,
+                    modificationDate: Date(),
+                    syncState: localItem.syncState,
+                    isPinned: localItem.isPinned,
+                    localPath: newLocalPath,
+                    remoteURL: localItem.remoteURL,
+                    contentVersion: "\(Date().timeIntervalSince1970)",
+                    tagData: newTagData,
+                    isLocal: true
+                )
+
+                try db.saveItems([updated])
+                completionHandler(FileProviderItem(localItem: updated), [], false, nil)
+            } catch {
+                logger.error("modifyItem failed: \(error.localizedDescription, privacy: .public)")
+                completionHandler(nil, [], false, error)
+            }
             return Progress()
         }
 
-        do {
-            var newFilename = localItem.filename
-            var newParentID = localItem.parentID
-            var newLocalPath = localItem.localPath
-            var newFileSize = localItem.fileSize
-            var newTagData = localItem.tagData
-
-            if changedFields.contains(.filename) {
-                newFilename = item.filename
+        // Non-local (synced) items: only tag edits from Finder are accepted.
+        if changedFields.contains(.tagData) {
+            let incomingTagData = item.tagData ?? nil
+            let parts = itemID.split(separator: "-")
+            if parts.first == "course", let courseID = parts.last.flatMap({ Int($0) }),
+               let siteID = self.siteID {
+                // Course root: keep course_tags table in sync so colors persist across re-syncs.
+                do {
+                    let newTags = incomingTagData.map { FinderTag.parseTags(from: $0) } ?? []
+                    try db.saveCourseTags(newTags, courseID: courseID, siteID: siteID)
+                    let tagData = FinderTag.tagData(from: newTags)
+                    try db.updateItemTagData(id: itemID, tagData: tagData)
+                    if let updatedItem = try db.fetchItem(id: itemID) {
+                        completionHandler(FileProviderItem(localItem: updatedItem), [], false, nil)
+                        return Progress()
+                    }
+                } catch {
+                    logger.error("Failed to update course tags from Finder: \(error.localizedDescription, privacy: .public)")
+                }
+            } else {
+                do {
+                    try db.updateItemTagData(id: itemID, tagData: incomingTagData)
+                    if let updatedItem = try db.fetchItem(id: itemID) {
+                        completionHandler(FileProviderItem(localItem: updatedItem), [], false, nil)
+                        return Progress()
+                    }
+                } catch {
+                    logger.error("Failed to update item tags: \(error.localizedDescription, privacy: .public)")
+                }
             }
-            if changedFields.contains(.parentItemIdentifier) {
-                newParentID = item.parentItemIdentifier == .rootContainer ? nil : item.parentItemIdentifier.rawValue
-            }
-            if changedFields.contains(.contents), let newContents {
-                let dest = try localContentURL(itemID: localItem.id)
-                try? FileManager.default.removeItem(at: dest)
-                try FileManager.default.copyItem(at: newContents, to: dest)
-                newLocalPath = dest.path
-                let attrs = try? FileManager.default.attributesOfItem(atPath: dest.path)
-                newFileSize = (attrs?[.size] as? Int64) ?? 0
-            }
-            if changedFields.contains(.tagData) {
-                newTagData = item.tagData ?? nil
-            }
-
-            let updated = LocalItem(
-                id: localItem.id,
-                parentID: newParentID,
-                siteID: localItem.siteID,
-                courseID: localItem.courseID,
-                remoteID: localItem.remoteID,
-                filename: newFilename,
-                isDirectory: localItem.isDirectory,
-                contentType: localItem.contentType,
-                fileSize: newFileSize,
-                creationDate: localItem.creationDate,
-                modificationDate: Date(),
-                syncState: localItem.syncState,
-                isPinned: localItem.isPinned,
-                localPath: newLocalPath,
-                remoteURL: localItem.remoteURL,
-                contentVersion: "\(Date().timeIntervalSince1970)",
-                tagData: newTagData,
-                isLocal: true
-            )
-
-            try db.saveItems([updated])
-            completionHandler(FileProviderItem(localItem: updated), [], false, nil)
-        } catch {
-            logger.error("modifyItem failed: \(error.localizedDescription, privacy: .public)")
-            completionHandler(nil, [], false, error)
         }
 
+        completionHandler(nil, [], false, NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError))
         return Progress()
     }
 

--- a/Sources/FileProviderExtension/FileProviderExtension.swift
+++ b/Sources/FileProviderExtension/FileProviderExtension.swift
@@ -47,6 +47,10 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         logger.info("File Provider extension initialized for domain: \(domain.identifier.rawValue, privacy: .public)")
     }
 
+    /// Has the orphaned-content sweep run for this extension instance?
+    /// Guarded by `stateLock`.
+    private var hasReconciledOrphans = false
+
     private func resolveDatabaseLocked() -> Database? {
         do {
             let stateDirectoryURL = try Self.stateDirectoryURL(for: domain)
@@ -166,6 +170,7 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         }
 
         if containerItemIdentifier == .workingSet {
+            reconcileOrphanedLocalContentIfNeeded()
             return WorkingSetEnumerator(database: db, siteID: siteID)
         }
 
@@ -364,7 +369,15 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
                     newFilename = item.filename
                 }
                 if changedFields.contains(.parentItemIdentifier) {
-                    newParentID = item.parentItemIdentifier == .rootContainer ? nil : item.parentItemIdentifier.rawValue
+                    let candidateParentID = item.parentItemIdentifier == .rootContainer
+                        ? nil
+                        : item.parentItemIdentifier.rawValue
+                    guard isReparentAllowed(itemID: localItem.id, newParentID: candidateParentID, db: db) else {
+                        logger.error("Rejected reparent of \(localItem.id, privacy: .public) to \(candidateParentID ?? "root", privacy: .public) — missing parent or cycle")
+                        completionHandler(nil, [], false, NSFileProviderError(.cannotSynchronize))
+                        return Progress()
+                    }
+                    newParentID = candidateParentID
                 }
                 if changedFields.contains(.contents), let newContents {
                     let dest = try localContentURL(itemID: localItem.id)
@@ -462,6 +475,76 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
 
         completionHandler(nil, [], false, NSFileProviderError(.cannotSynchronize))
         return Progress()
+    }
+
+    /// Whether moving `itemID` under `newParentID` is structurally valid.
+    /// Rejects moves whose new parent is missing (would orphan the item) or
+    /// that would place the item inside itself or one of its descendants
+    /// (a cycle). Moving to the root (`nil`) is always allowed.
+    private func isReparentAllowed(itemID: String, newParentID: String?, db: Database) -> Bool {
+        guard let newParentID else { return true }
+        if newParentID == itemID { return false }
+
+        // Walk the ancestor chain of the proposed parent. If it leads back to
+        // the item being moved, the move would create a cycle. A missing
+        // ancestor means the chain is orphaned, so reject that too. `visited`
+        // guards against pre-existing corrupt loops in the data.
+        var cursor: String? = newParentID
+        var visited: Set<String> = []
+        while let current = cursor {
+            if current == itemID { return false }
+            guard visited.insert(current).inserted else { return false }
+            guard let parent = try? db.fetchItem(id: current) else { return false }
+            cursor = parent.parentID
+        }
+        return true
+    }
+
+    // MARK: - Maintenance
+
+    /// Sweep `LocalContent/` for files with no corresponding local item and
+    /// remove them. Partial failures during create/modify/delete can leave such
+    /// orphans behind, growing disk usage unbounded. Runs at most once per
+    /// extension instance, off the request thread.
+    private func reconcileOrphanedLocalContentIfNeeded() {
+        stateLock.lock()
+        let alreadyRan = hasReconciledOrphans
+        hasReconciledOrphans = true
+        stateLock.unlock()
+
+        guard !alreadyRan, let db = database else { return }
+        guard let directory = try? localContentDirectory() else { return }
+
+        let log = logger
+        DispatchQueue.global(qos: .utility).async {
+            Self.reconcileOrphanedLocalContent(directory: directory, database: db, logger: log)
+        }
+    }
+
+    private static func reconcileOrphanedLocalContent(directory: URL, database: Database, logger: Logger) {
+        let fileManager = FileManager.default
+        guard let entries = try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil
+        ) else { return }
+
+        var removed = 0
+        for fileURL in entries {
+            // Local content is stored under the item's own identifier.
+            let itemID = fileURL.lastPathComponent
+            if let item = try? database.fetchItem(id: itemID), item.isLocal {
+                continue
+            }
+            do {
+                try fileManager.removeItem(at: fileURL)
+                removed += 1
+            } catch {
+                logger.warning("Failed to remove orphaned local content \(itemID, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
+        }
+        if removed > 0 {
+            logger.info("Reconciled \(removed) orphaned local content file(s)")
+        }
     }
 
     func deleteItem(

--- a/Sources/FileProviderExtension/FileProviderExtension.swift
+++ b/Sources/FileProviderExtension/FileProviderExtension.swift
@@ -283,7 +283,11 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
 
         let itemID = "local-\(UUID().uuidString)"
         let now = Date()
-        let isDirectory = itemTemplate.contentType == .folder
+        // Use `conforms(to:)` so app bundles (.app, .pkg) and other directory
+        // subtypes are treated as folders. Equality check on `.folder` misses
+        // these and they would be saved as flat files with the bundle's
+        // documentSize, losing the inner contents.
+        let isDirectory = itemTemplate.contentType?.conforms(to: .directory) == true
 
         var localItem = LocalItem(
             id: itemID,
@@ -301,17 +305,24 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
             isLocal: true
         )
 
+        var stagedContentURL: URL?
         do {
             // Persist file content for non-directory items.
             if !isDirectory, let contentURL = url {
                 let dest = try localContentURL(itemID: itemID)
                 try FileManager.default.copyItem(at: contentURL, to: dest)
+                stagedContentURL = dest
                 localItem.localPath = dest.path
             }
 
             try db.saveItems([localItem])
             completionHandler(FileProviderItem(localItem: localItem), [], false, nil)
         } catch {
+            // Roll back the staged content file so we don't leave orphans in
+            // LocalContent/ when the DB write fails.
+            if let stagedContentURL {
+                try? FileManager.default.removeItem(at: stagedContentURL)
+            }
             logger.error("createItem failed: \(error.localizedDescription, privacy: .public)")
             completionHandler(nil, [], false, error)
         }
@@ -398,6 +409,20 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         }
 
         // Non-local (synced) items: only tag edits from Finder are accepted.
+        // Use NSFileProviderError so the OS reverts the user's local change
+        // gracefully instead of leaving Finder in an inconsistent state.
+        var unsupportedFields = changedFields
+        unsupportedFields.remove(.tagData)
+        guard changedFields.contains(.tagData), unsupportedFields.isEmpty else {
+            completionHandler(
+                nil,
+                changedFields,
+                false,
+                NSFileProviderError(.cannotSynchronize)
+            )
+            return Progress()
+        }
+
         if changedFields.contains(.tagData) {
             let incomingTagData = item.tagData ?? nil
             let parts = itemID.split(separator: "-")
@@ -411,25 +436,31 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
                     try db.updateItemTagData(id: itemID, tagData: tagData)
                     if let updatedItem = try db.fetchItem(id: itemID) {
                         completionHandler(FileProviderItem(localItem: updatedItem), [], false, nil)
-                        return Progress()
+                    } else {
+                        completionHandler(nil, [], false, NSFileProviderError(.noSuchItem))
                     }
                 } catch {
                     logger.error("Failed to update course tags from Finder: \(error.localizedDescription, privacy: .public)")
+                    completionHandler(nil, [], false, error)
                 }
+                return Progress()
             } else {
                 do {
                     try db.updateItemTagData(id: itemID, tagData: incomingTagData)
                     if let updatedItem = try db.fetchItem(id: itemID) {
                         completionHandler(FileProviderItem(localItem: updatedItem), [], false, nil)
-                        return Progress()
+                    } else {
+                        completionHandler(nil, [], false, NSFileProviderError(.noSuchItem))
                     }
                 } catch {
                     logger.error("Failed to update item tags: \(error.localizedDescription, privacy: .public)")
+                    completionHandler(nil, [], false, error)
                 }
+                return Progress()
             }
         }
 
-        completionHandler(nil, [], false, NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError))
+        completionHandler(nil, [], false, NSFileProviderError(.cannotSynchronize))
         return Progress()
     }
 
@@ -450,9 +481,11 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
             return Progress()
         }
 
-        // Only allow deletion of local items.
+        // Only allow deletion of local items. Synced items can't be deleted
+        // through Finder — surface the proper File Provider error so the OS
+        // restores the file rather than leaving the Finder UI inconsistent.
         guard localItem.isLocal else {
-            completionHandler(NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError))
+            completionHandler(NSFileProviderError(.cannotSynchronize))
             return Progress()
         }
 

--- a/Sources/FileProviderExtension/ItemEnumerator.swift
+++ b/Sources/FileProviderExtension/ItemEnumerator.swift
@@ -4,9 +4,28 @@
 // You may obtain a copy of the License in the LICENSE file at the root of this repository.
 
 import FileProvider
+import Foundation
 import SharedDomain
 import FoodlePersistence
 import OSLog
+
+/// Sync anchors are opaque to the system, but we use them as a decimal-encoded
+/// Int64 representing the database's monotonic change counter. Encoding as a
+/// decimal string keeps them human-readable in logs while round-tripping
+/// losslessly through `Data`.
+enum SyncAnchorCoding {
+    static func encode(_ value: Int64) -> NSFileProviderSyncAnchor {
+        NSFileProviderSyncAnchor(Data(String(value).utf8))
+    }
+
+    static func decode(_ anchor: NSFileProviderSyncAnchor) -> Int64 {
+        guard let s = String(data: anchor.rawValue, encoding: .utf8),
+              let value = Int64(s) else {
+            return 0
+        }
+        return value
+    }
+}
 
 /// Enumerates items within a container (course folder, section folder, etc.).
 final class ItemEnumerator: NSObject, NSFileProviderEnumerator {
@@ -62,24 +81,28 @@ final class ItemEnumerator: NSObject, NSFileProviderEnumerator {
                 parentID = containerIdentifier.rawValue
             }
 
-            let items = try database.fetchItems(parentID: parentID)
-            let providerItems = items.map { FileProviderItem(localItem: $0) }
+            let fromCounter = SyncAnchorCoding.decode(anchor)
+            // Only items whose updated_at exceeds the incoming anchor; the
+            // trigger on writes guarantees updated_at is strictly increasing.
+            let changedItems = try database.fetchItemsChangedSince(anchor: fromCounter, parentID: parentID)
+            let providerItems = changedItems.map { FileProviderItem(localItem: $0) }
 
             if !providerItems.isEmpty {
                 observer.didUpdate(providerItems)
             }
 
-            let deletedIDs = try database.fetchPendingDeletions()
+            let deletedIDs = try database.fetchPendingDeletionsSince(anchor: fromCounter)
             if !deletedIDs.isEmpty {
                 let identifiers = deletedIDs.map { NSFileProviderItemIdentifier($0) }
                 observer.didDeleteItems(withIdentifiers: identifiers)
-                // Drop the tombstones we just reported so the next change
-                // enumeration doesn't replay the same deletions forever.
+                // Drop the tombstones we just reported so the table doesn't
+                // grow unbounded — they're identified by their counter, which
+                // already protects against re-reporting on the next call.
                 try? database.clearPendingDeletions(ids: deletedIDs)
             }
 
-            let newAnchor = NSFileProviderSyncAnchor(Data("\(Date().timeIntervalSince1970)".utf8))
-            observer.finishEnumeratingChanges(upTo: newAnchor, moreComing: false)
+            let newCounter = try database.currentChangeCounter()
+            observer.finishEnumeratingChanges(upTo: SyncAnchorCoding.encode(newCounter), moreComing: false)
         } catch {
             logger.error("Change enumeration failed: \(error.localizedDescription, privacy: .public)")
             observer.finishEnumeratingWithError(error)
@@ -87,8 +110,8 @@ final class ItemEnumerator: NSObject, NSFileProviderEnumerator {
     }
 
     func currentSyncAnchor(completionHandler: @escaping (NSFileProviderSyncAnchor?) -> Void) {
-        let anchorData = Data("\(Date().timeIntervalSince1970)".utf8)
-        completionHandler(NSFileProviderSyncAnchor(anchorData))
+        let counter = (try? database.currentChangeCounter()) ?? 0
+        completionHandler(SyncAnchorCoding.encode(counter))
     }
 }
 
@@ -136,37 +159,36 @@ final class WorkingSetEnumerator: NSObject, NSFileProviderEnumerator {
         from anchor: NSFileProviderSyncAnchor
     ) {
         do {
-            let items: [LocalItem]
+            let fromCounter = SyncAnchorCoding.decode(anchor)
+            let changedItems: [LocalItem]
             if let siteID {
-                items = try database.fetchAllItems(siteID: siteID)
+                changedItems = try database.fetchItemsChangedSince(anchor: fromCounter, siteID: siteID)
             } else {
-                items = try database.fetchItems(parentID: nil)
+                changedItems = try database.fetchItemsChangedSince(anchor: fromCounter, parentID: nil)
             }
 
-            let providerItems = items.map { FileProviderItem(localItem: $0) }
+            let providerItems = changedItems.map { FileProviderItem(localItem: $0) }
 
             if !providerItems.isEmpty {
                 observer.didUpdate(providerItems)
             }
 
-            let deletedIDs = try database.fetchPendingDeletions()
+            let deletedIDs = try database.fetchPendingDeletionsSince(anchor: fromCounter)
             if !deletedIDs.isEmpty {
                 let identifiers = deletedIDs.map { NSFileProviderItemIdentifier($0) }
                 observer.didDeleteItems(withIdentifiers: identifiers)
-                // Drop the tombstones we just reported so the next change
-                // enumeration doesn't replay the same deletions forever.
                 try? database.clearPendingDeletions(ids: deletedIDs)
             }
 
-            let newAnchor = NSFileProviderSyncAnchor(Data("\(Date().timeIntervalSince1970)".utf8))
-            observer.finishEnumeratingChanges(upTo: newAnchor, moreComing: false)
+            let newCounter = try database.currentChangeCounter()
+            observer.finishEnumeratingChanges(upTo: SyncAnchorCoding.encode(newCounter), moreComing: false)
         } catch {
             observer.finishEnumeratingWithError(error)
         }
     }
 
     func currentSyncAnchor(completionHandler: @escaping (NSFileProviderSyncAnchor?) -> Void) {
-        let anchorData = Data("\(Date().timeIntervalSince1970)".utf8)
-        completionHandler(NSFileProviderSyncAnchor(anchorData))
+        let counter = (try? database.currentChangeCounter()) ?? 0
+        completionHandler(SyncAnchorCoding.encode(counter))
     }
 }

--- a/Sources/FileProviderExtension/ItemEnumerator.swift
+++ b/Sources/FileProviderExtension/ItemEnumerator.swift
@@ -73,6 +73,9 @@ final class ItemEnumerator: NSObject, NSFileProviderEnumerator {
             if !deletedIDs.isEmpty {
                 let identifiers = deletedIDs.map { NSFileProviderItemIdentifier($0) }
                 observer.didDeleteItems(withIdentifiers: identifiers)
+                // Drop the tombstones we just reported so the next change
+                // enumeration doesn't replay the same deletions forever.
+                try? database.clearPendingDeletions(ids: deletedIDs)
             }
 
             let newAnchor = NSFileProviderSyncAnchor(Data("\(Date().timeIntervalSince1970)".utf8))
@@ -150,6 +153,9 @@ final class WorkingSetEnumerator: NSObject, NSFileProviderEnumerator {
             if !deletedIDs.isEmpty {
                 let identifiers = deletedIDs.map { NSFileProviderItemIdentifier($0) }
                 observer.didDeleteItems(withIdentifiers: identifiers)
+                // Drop the tombstones we just reported so the next change
+                // enumeration doesn't replay the same deletions forever.
+                try? database.clearPendingDeletions(ids: deletedIDs)
             }
 
             let newAnchor = NSFileProviderSyncAnchor(Data("\(Date().timeIntervalSince1970)".utf8))

--- a/Sources/FileProviderExtension/ItemEnumerator.swift
+++ b/Sources/FileProviderExtension/ItemEnumerator.swift
@@ -95,10 +95,6 @@ final class ItemEnumerator: NSObject, NSFileProviderEnumerator {
             if !deletedIDs.isEmpty {
                 let identifiers = deletedIDs.map { NSFileProviderItemIdentifier($0) }
                 observer.didDeleteItems(withIdentifiers: identifiers)
-                // Drop the tombstones we just reported so the table doesn't
-                // grow unbounded — they're identified by their counter, which
-                // already protects against re-reporting on the next call.
-                try? database.clearPendingDeletions(ids: deletedIDs)
             }
 
             let newCounter = try database.currentChangeCounter()
@@ -177,7 +173,6 @@ final class WorkingSetEnumerator: NSObject, NSFileProviderEnumerator {
             if !deletedIDs.isEmpty {
                 let identifiers = deletedIDs.map { NSFileProviderItemIdentifier($0) }
                 observer.didDeleteItems(withIdentifiers: identifiers)
-                try? database.clearPendingDeletions(ids: deletedIDs)
             }
 
             let newCounter = try database.currentChangeCounter()

--- a/Sources/Networking/Auth/KeychainManager.swift
+++ b/Sources/Networking/Auth/KeychainManager.swift
@@ -21,15 +21,30 @@ public final class KeychainManager: Sendable {
     public func storeToken(_ token: String, forAccount account: String) throws {
         let data = Data(token.utf8)
 
-        // Delete existing item first
-        let deleteQuery: [String: Any] = [
+        // Try update-in-place first so the credential isn't briefly absent
+        // between a delete and an add — if the process is killed mid-write
+        // the user would silently be logged out. SecItemUpdate is atomic
+        // and also normalises any accessibility-class mismatch from older
+        // builds (where the item may have been stored with WhenUnlocked).
+        let lookupQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account
         ]
-        SecItemDelete(deleteQuery as CFDictionary)
+        let updateAttributes: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
+        ]
+        let updateStatus = SecItemUpdate(lookupQuery as CFDictionary, updateAttributes as CFDictionary)
+        if updateStatus == errSecSuccess {
+            return
+        }
+        guard updateStatus == errSecItemNotFound else {
+            logger.error("Keychain update failed: \(updateStatus)")
+            throw KeychainError.storeFailed(status: updateStatus)
+        }
 
-        // Add new item
+        // Item doesn't exist yet — add it.
         let addQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
@@ -38,10 +53,10 @@ public final class KeychainManager: Sendable {
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
         ]
 
-        let status = SecItemAdd(addQuery as CFDictionary, nil)
-        guard status == errSecSuccess else {
-            logger.error("Failed to store token: \(status)")
-            throw KeychainError.storeFailed(status: status)
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        guard addStatus == errSecSuccess else {
+            logger.error("Keychain add failed: \(addStatus)")
+            throw KeychainError.storeFailed(status: addStatus)
         }
     }
 

--- a/Sources/Networking/Auth/WebAuthSession.swift
+++ b/Sources/Networking/Auth/WebAuthSession.swift
@@ -92,7 +92,10 @@ public final class WebAuthSession: NSObject {
         logger.info("Login type: \(String(describing: site.capabilities.loginType), privacy: .public)")
         logger.info("Discovered launchurl: \(site.capabilities.launchURL ?? "<none>", privacy: .public)")
         logger.info("Launch URL source: \(buildResult.source == .advertised ? "advertised" : "fallback", privacy: .public)")
-        logger.info("Final SSO launch URL: \(launchURL.absoluteString, privacy: .public)")
+        // The launch URL embeds the passport nonce used to sign the SSO
+        // callback — log only the host publicly, keep the full URL private.
+        logger.info("Final SSO launch URL host: \(launchURL.host ?? "<unknown>", privacy: .public)")
+        logger.debug("Final SSO launch URL: \(launchURL.absoluteString, privacy: .private)")
 
         let callbackURL: URL
         do {

--- a/Sources/Networking/Client/LMSProvider.swift
+++ b/Sources/Networking/Client/LMSProvider.swift
@@ -45,8 +45,13 @@ public protocol LMSProvider: Sendable {
     /// Download a file to a local path.
     func downloadFile(url: URL, token: AuthToken, destination: URL) async throws
 
-    /// Construct an authenticated download URL for a file.
-    func authenticatedFileURL(fileURL: URL, token: AuthToken) -> URL
+    /// Build the URLRequest that downloads `fileURL` with the given token.
+    ///
+    /// The token is sent in the POST body instead of the URL query so it
+    /// doesn't leak into URL access logs, URLSession metrics, the `Referer`
+    /// header on cross-host CDN redirects, or crash reports that include the
+    /// in-flight request URL.
+    func authenticatedFileRequest(fileURL: URL, token: AuthToken) -> URLRequest
 }
 
 /// Represents an authentication token for a Moodle session.

--- a/Sources/Networking/Client/MoodleClient.swift
+++ b/Sources/Networking/Client/MoodleClient.swift
@@ -244,19 +244,17 @@ public final class MoodleClient: LMSProvider, Sendable {
     public func authenticate(site: MoodleSite, username: String, password: String) async throws -> AuthToken {
         logger.info("Authenticating user \(username, privacy: .private) at \(site.baseURL.host ?? "", privacy: .public)")
 
-        guard var components = URLComponents(url: site.tokenURL, resolvingAgainstBaseURL: false) else {
-            throw FoodleError.internalError(detail: "Could not parse token URL.")
-        }
-        components.queryItems = [
-            URLQueryItem(name: "username", value: username),
-            URLQueryItem(name: "password", value: password),
-            URLQueryItem(name: "service", value: "moodle_mobile_app")
-        ]
-
+        // Build the body explicitly so '+' in a password isn't double-decoded
+        // as a space by Moodle. URLQueryItem's default escaping leaves '+'
+        // unescaped, which Moodle's form decoder then interprets as a space.
         var request = URLRequest(url: site.tokenURL)
         request.httpMethod = "POST"
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
-        request.httpBody = components.percentEncodedQuery?.data(using: .utf8)
+        request.httpBody = Self.formEncode([
+            "username": username,
+            "password": password,
+            "service": "moodle_mobile_app"
+        ])
 
         let (data, _) = try await performRequest(request)
         let tokenResponse = try Self.makeDecoder().decode(TokenResponse.self, from: data)
@@ -486,8 +484,7 @@ public final class MoodleClient: LMSProvider, Sendable {
     // MARK: - File Download
 
     public func downloadFile(url: URL, token: AuthToken, destination: URL) async throws {
-        let authenticatedURL = authenticatedFileURL(fileURL: url, token: token)
-        let request = URLRequest(url: authenticatedURL)
+        let request = authenticatedFileRequest(fileURL: url, token: token)
 
         let (tempURL, response) = try await session.download(for: request)
 
@@ -506,14 +503,16 @@ public final class MoodleClient: LMSProvider, Sendable {
         try fileManager.moveItem(at: tempURL, to: destination)
     }
 
-    public func authenticatedFileURL(fileURL: URL, token: AuthToken) -> URL {
-        guard var components = URLComponents(url: fileURL, resolvingAgainstBaseURL: false) else {
-            return fileURL
-        }
-        var items = components.queryItems ?? []
-        items.append(URLQueryItem(name: "token", value: token.token))
-        components.queryItems = items
-        return components.url ?? fileURL
+    public func authenticatedFileRequest(fileURL: URL, token: AuthToken) -> URLRequest {
+        // Moodle's pluginfile.php accepts the token via either $_GET or $_POST.
+        // Send it via POST body so the token doesn't end up in URL logs, the
+        // Referer header on CDN redirects, or URLSession metrics. The URL
+        // itself stays clean.
+        var request = URLRequest(url: fileURL)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Self.formEncode(["token": token.token])
+        return request
     }
 
     // MARK: - Web Service Call
@@ -524,24 +523,23 @@ public final class MoodleClient: LMSProvider, Sendable {
         function: String,
         params: [String: String] = [:]
     ) async throws -> T {
-        guard var components = URLComponents(url: site.webServiceURL, resolvingAgainstBaseURL: false) else {
-            throw FoodleError.internalError(detail: "Could not construct web service URL.")
-        }
-        var queryItems = [
-            URLQueryItem(name: "wstoken", value: token.token),
-            URLQueryItem(name: "wsfunction", value: function),
-            URLQueryItem(name: "moodlewsrestformat", value: "json")
+        // POST the credentials and parameters in the body so wstoken never
+        // ends up in URL logs, proxy access logs, or crash reports. Moodle's
+        // webservice/rest/server.php accepts either GET or POST.
+        var body: [String: String] = [
+            "wstoken": token.token,
+            "wsfunction": function,
+            "moodlewsrestformat": "json"
         ]
         for (key, value) in params {
-            queryItems.append(URLQueryItem(name: key, value: value))
-        }
-        components.queryItems = queryItems
-
-        guard let url = components.url else {
-            throw FoodleError.internalError(detail: "Could not construct web service URL.")
+            body[key] = value
         }
 
-        let request = URLRequest(url: url)
+        var request = URLRequest(url: site.webServiceURL)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Self.formEncode(body)
+
         let (data, response) = try await performRequest(request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
@@ -673,6 +671,23 @@ public final class MoodleClient: LMSProvider, Sendable {
         default:
             return nil
         }
+    }
+
+    // MARK: - Form Encoding
+
+    /// Form-encode a dictionary into the body of an `application/x-www-form-urlencoded`
+    /// request. Uses an explicit allowed set that excludes `+`, `&`, `=`, `?`, and `#` so
+    /// special characters in passwords or other values can't be misinterpreted on the
+    /// receiving side.
+    static func formEncode(_ fields: [String: String]) -> Data? {
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")
+        let parts: [String] = fields.map { key, value in
+            let encodedKey = key.addingPercentEncoding(withAllowedCharacters: allowed) ?? key
+            let encodedValue = value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
+            return "\(encodedKey)=\(encodedValue)"
+        }
+        return parts.joined(separator: "&").data(using: .utf8)
     }
 
     // MARK: - URL Normalization

--- a/Sources/Persistence/Database.swift
+++ b/Sources/Persistence/Database.swift
@@ -23,7 +23,7 @@ public final class Database: @unchecked Sendable {
     private let path: String
     public var filePath: String { path }
 
-    public static let schemaVersion = 10
+    public static let schemaVersion = 11
 
     public init(path: String? = nil) throws {
         if let path = path {
@@ -188,7 +188,8 @@ public final class Database: @unchecked Sendable {
                 local_path TEXT,
                 remote_url TEXT,
                 content_version TEXT,
-                tag_data BLOB
+                tag_data BLOB,
+                updated_at INTEGER NOT NULL DEFAULT 0
             )
         """)
 
@@ -216,8 +217,52 @@ public final class Database: @unchecked Sendable {
         try execute("""
             CREATE TABLE IF NOT EXISTS pending_deletions (
                 item_id TEXT PRIMARY KEY,
-                deleted_at REAL NOT NULL DEFAULT (strftime('%s', 'now'))
+                deleted_at REAL NOT NULL DEFAULT (strftime('%s', 'now')),
+                deleted_at_counter INTEGER NOT NULL DEFAULT 0
             )
+        """)
+
+        try execute("""
+            CREATE TABLE IF NOT EXISTS system_metadata (
+                key TEXT PRIMARY KEY,
+                value INTEGER NOT NULL
+            )
+        """)
+        try execute("INSERT OR IGNORE INTO system_metadata (key, value) VALUES ('change_counter', 0)")
+
+        try execute("CREATE INDEX IF NOT EXISTS idx_items_updated_at ON items(updated_at)")
+        try execute("CREATE INDEX IF NOT EXISTS idx_pending_deletions_counter ON pending_deletions(deleted_at_counter)")
+
+        // Triggers that stamp items.updated_at and pending_deletions.deleted_at_counter
+        // with a monotonic global counter on every write. The `WHEN NEW.<col> = 0`
+        // guard skips already-stamped rows (e.g., during migration where we set the
+        // value explicitly) so the trigger doesn't recurse and doesn't re-stamp.
+        try execute("""
+            CREATE TRIGGER IF NOT EXISTS items_bump_after_insert
+            AFTER INSERT ON items
+            WHEN NEW.updated_at = 0
+            BEGIN
+                UPDATE system_metadata SET value = value + 1 WHERE key = 'change_counter';
+                UPDATE items SET updated_at = (SELECT value FROM system_metadata WHERE key = 'change_counter') WHERE id = NEW.id;
+            END
+        """)
+        try execute("""
+            CREATE TRIGGER IF NOT EXISTS items_bump_after_update
+            AFTER UPDATE OF parent_id, filename, file_size, sync_state, is_pinned, local_path, remote_url, content_version, tag_data, is_local, modification_date
+            ON items
+            BEGIN
+                UPDATE system_metadata SET value = value + 1 WHERE key = 'change_counter';
+                UPDATE items SET updated_at = (SELECT value FROM system_metadata WHERE key = 'change_counter') WHERE id = NEW.id;
+            END
+        """)
+        try execute("""
+            CREATE TRIGGER IF NOT EXISTS pending_deletions_bump_after_insert
+            AFTER INSERT ON pending_deletions
+            WHEN NEW.deleted_at_counter = 0
+            BEGIN
+                UPDATE system_metadata SET value = value + 1 WHERE key = 'change_counter';
+                UPDATE pending_deletions SET deleted_at_counter = (SELECT value FROM system_metadata WHERE key = 'change_counter') WHERE item_id = NEW.item_id;
+            END
         """)
 
         try execute("""
@@ -339,6 +384,78 @@ public final class Database: @unchecked Sendable {
             try execute("DROP TABLE pending_deletions")
             try execute("ALTER TABLE pending_deletions_new RENAME TO pending_deletions")
             logger.info("Migrated database schema to version 10 (pending_deletions dedupe)")
+        }
+
+        if currentVersion < 11 {
+            // Add a monotonic change counter so the File Provider extension can
+            // do incremental change enumeration instead of re-emitting every
+            // item on every poll. The counter is bumped by triggers on writes
+            // to items and pending_deletions; the value at write time is
+            // stamped onto each row so enumerateChanges can filter.
+            let itemColumns = try existingColumns(table: "items")
+            if !itemColumns.contains("updated_at") {
+                try execute("ALTER TABLE items ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0")
+            }
+            let pendingColumns = try existingColumns(table: "pending_deletions")
+            if !pendingColumns.contains("deleted_at_counter") {
+                try execute("ALTER TABLE pending_deletions ADD COLUMN deleted_at_counter INTEGER NOT NULL DEFAULT 0")
+            }
+            try execute("""
+                CREATE TABLE IF NOT EXISTS system_metadata (
+                    key TEXT PRIMARY KEY,
+                    value INTEGER NOT NULL
+                )
+            """)
+            try execute("INSERT OR IGNORE INTO system_metadata (key, value) VALUES ('change_counter', 0)")
+
+            // Seed updated_at for existing items so they're treated as having
+            // changed once at migration time, and advance the counter past
+            // every existing row so future writes get unique values. Same for
+            // pre-existing pending_deletions rows.
+            try execute("UPDATE items SET updated_at = rowid WHERE updated_at = 0")
+            try execute("UPDATE pending_deletions SET deleted_at_counter = (SELECT COALESCE(MAX(updated_at), 0) FROM items) + rowid WHERE deleted_at_counter = 0")
+            try execute("""
+                UPDATE system_metadata
+                SET value = (
+                    SELECT MAX(c) FROM (
+                        SELECT COALESCE(MAX(updated_at), 0) AS c FROM items
+                        UNION ALL
+                        SELECT COALESCE(MAX(deleted_at_counter), 0) FROM pending_deletions
+                    )
+                )
+                WHERE key = 'change_counter'
+            """)
+
+            try execute("CREATE INDEX IF NOT EXISTS idx_items_updated_at ON items(updated_at)")
+            try execute("CREATE INDEX IF NOT EXISTS idx_pending_deletions_counter ON pending_deletions(deleted_at_counter)")
+            try execute("""
+                CREATE TRIGGER IF NOT EXISTS items_bump_after_insert
+                AFTER INSERT ON items
+                WHEN NEW.updated_at = 0
+                BEGIN
+                    UPDATE system_metadata SET value = value + 1 WHERE key = 'change_counter';
+                    UPDATE items SET updated_at = (SELECT value FROM system_metadata WHERE key = 'change_counter') WHERE id = NEW.id;
+                END
+            """)
+            try execute("""
+                CREATE TRIGGER IF NOT EXISTS items_bump_after_update
+                AFTER UPDATE OF parent_id, filename, file_size, sync_state, is_pinned, local_path, remote_url, content_version, tag_data, is_local, modification_date
+                ON items
+                BEGIN
+                    UPDATE system_metadata SET value = value + 1 WHERE key = 'change_counter';
+                    UPDATE items SET updated_at = (SELECT value FROM system_metadata WHERE key = 'change_counter') WHERE id = NEW.id;
+                END
+            """)
+            try execute("""
+                CREATE TRIGGER IF NOT EXISTS pending_deletions_bump_after_insert
+                AFTER INSERT ON pending_deletions
+                WHEN NEW.deleted_at_counter = 0
+                BEGIN
+                    UPDATE system_metadata SET value = value + 1 WHERE key = 'change_counter';
+                    UPDATE pending_deletions SET deleted_at_counter = (SELECT value FROM system_metadata WHERE key = 'change_counter') WHERE item_id = NEW.item_id;
+                END
+            """)
+            logger.info("Migrated database schema to version 11 (monotonic change counter)")
         }
 
         try execute("PRAGMA user_version = \(Self.schemaVersion)")
@@ -1144,6 +1261,69 @@ extension Database {
         return try queue.sync {
             let stmt = try prepareStatement(sql)
             defer { sqlite3_finalize(stmt) }
+            var ids: [String] = []
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                ids.append(String(cString: sqlite3_column_text(stmt, 0)))
+            }
+            return ids
+        }
+    }
+
+    /// Return the global monotonic change counter. The value is bumped by SQL
+    /// triggers on writes to `items` and `pending_deletions`, so it's safe to
+    /// use as a sync anchor handed to NSFileProviderChangeObserver.
+    public func currentChangeCounter() throws -> Int64 {
+        try queue.sync {
+            let stmt = try prepareStatement("SELECT value FROM system_metadata WHERE key = 'change_counter'")
+            defer { sqlite3_finalize(stmt) }
+            guard sqlite3_step(stmt) == SQLITE_ROW else { return 0 }
+            return sqlite3_column_int64(stmt, 0)
+        }
+    }
+
+    /// Return items in a container whose `updated_at` is strictly greater than `anchor`.
+    /// Pass `parentID == nil` for root items, or a parent ID for a single container.
+    public func fetchItemsChangedSince(anchor: Int64, parentID: String?) throws -> [LocalItem] {
+        let sql: String
+        if parentID == nil {
+            sql = "SELECT * FROM items WHERE parent_id IS NULL AND updated_at > ? ORDER BY updated_at"
+        } else {
+            sql = "SELECT * FROM items WHERE parent_id = ? AND updated_at > ? ORDER BY updated_at"
+        }
+        return try queue.sync {
+            let stmt = try prepareStatement(sql)
+            defer { sqlite3_finalize(stmt) }
+            if let parentID {
+                sqlite3_bind_text(stmt, 1, (parentID as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                sqlite3_bind_int64(stmt, 2, anchor)
+            } else {
+                sqlite3_bind_int64(stmt, 1, anchor)
+            }
+            return try readItems(from: stmt)
+        }
+    }
+
+    /// Return all items for a site whose `updated_at` is strictly greater than `anchor`.
+    public func fetchItemsChangedSince(anchor: Int64, siteID: String) throws -> [LocalItem] {
+        let sql = "SELECT * FROM items WHERE site_id = ? AND updated_at > ? ORDER BY updated_at"
+        return try queue.sync {
+            let stmt = try prepareStatement(sql)
+            defer { sqlite3_finalize(stmt) }
+            sqlite3_bind_text(stmt, 1, (siteID as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_int64(stmt, 2, anchor)
+            return try readItems(from: stmt)
+        }
+    }
+
+    /// Pending-deletion IDs whose `deleted_at_counter` is strictly greater
+    /// than `anchor`. Returned in counter order so the enumerator can derive
+    /// the next anchor from the last entry.
+    public func fetchPendingDeletionsSince(anchor: Int64) throws -> [String] {
+        let sql = "SELECT item_id FROM pending_deletions WHERE deleted_at_counter > ? ORDER BY deleted_at_counter"
+        return try queue.sync {
+            let stmt = try prepareStatement(sql)
+            defer { sqlite3_finalize(stmt) }
+            sqlite3_bind_int64(stmt, 1, anchor)
             var ids: [String] = []
             while sqlite3_step(stmt) == SQLITE_ROW {
                 ids.append(String(cString: sqlite3_column_text(stmt, 0)))

--- a/Sources/Persistence/Database.swift
+++ b/Sources/Persistence/Database.swift
@@ -17,7 +17,7 @@ public final class Database: @unchecked Sendable {
     private let path: String
     public var filePath: String { path }
 
-    public static let schemaVersion = 8
+    public static let schemaVersion = 9
 
     public init(path: String? = nil) throws {
         if let path = path {
@@ -306,7 +306,61 @@ public final class Database: @unchecked Sendable {
             logger.info("Migrated database schema to version 8 (local items)")
         }
 
+        if currentVersion < 9 {
+            // Regenerate all tagData blobs: previously used NSKeyedArchiver encoding
+            // which Finder doesn't correctly interpret. Now uses PropertyListSerialization
+            // (binary plist) which matches the com.apple.metadata:_kMDItemUserTags format.
+            try regenerateAllTagData()
+            logger.info("Migrated database schema to version 9 (fixed tag data encoding)")
+        }
+
         try execute("PRAGMA user_version = \(Self.schemaVersion)")
+    }
+
+    /// Regenerate tag_data blobs for all course items from course_tags table.
+    private func regenerateAllTagData() throws {
+        try queue.sync {
+            // Find all distinct (course_id, site_id) pairs with tags
+            let keysStmt = try prepareStatement("SELECT DISTINCT course_id, site_id FROM course_tags")
+            defer { sqlite3_finalize(keysStmt) }
+
+            var courseKeys: [(courseID: Int, siteID: String)] = []
+            while sqlite3_step(keysStmt) == SQLITE_ROW {
+                let courseID = Int(sqlite3_column_int64(keysStmt, 0))
+                let siteID = String(cString: sqlite3_column_text(keysStmt, 1))
+                courseKeys.append((courseID, siteID))
+            }
+
+            for key in courseKeys {
+                let tagStmt = try prepareStatement(
+                    "SELECT tag_name, tag_color FROM course_tags WHERE course_id = ? AND site_id = ? ORDER BY tag_name"
+                )
+                defer { sqlite3_finalize(tagStmt) }
+                sqlite3_bind_int64(tagStmt, 1, Int64(key.courseID))
+                sqlite3_bind_text(tagStmt, 2, (key.siteID as NSString).utf8String, -1, nil)
+
+                var tags: [FinderTag] = []
+                while sqlite3_step(tagStmt) == SQLITE_ROW {
+                    let name = String(cString: sqlite3_column_text(tagStmt, 0))
+                    let colorRaw = Int(sqlite3_column_int(tagStmt, 1))
+                    let color = FinderTag.Color(rawValue: colorRaw) ?? .none
+                    tags.append(FinderTag(name: name, color: color))
+                }
+
+                let itemID = "course-\(key.siteID)-\(key.courseID)"
+                let tagData = FinderTag.tagData(from: tags)
+
+                let updateStmt = try prepareStatement("UPDATE items SET tag_data = ? WHERE id = ?")
+                defer { sqlite3_finalize(updateStmt) }
+                if let td = tagData {
+                    sqlite3_bind_blob(updateStmt, 1, (td as NSData).bytes, Int32(td.count), nil)
+                } else {
+                    sqlite3_bind_null(updateStmt, 1)
+                }
+                sqlite3_bind_text(updateStmt, 2, (itemID as NSString).utf8String, -1, nil)
+                _ = sqlite3_step(updateStmt)
+            }
+        }
     }
 
     private func existingColumns(table: String) throws -> Set<String> {

--- a/Sources/Persistence/Database.swift
+++ b/Sources/Persistence/Database.swift
@@ -8,6 +8,12 @@ import SQLite3
 import OSLog
 import SharedDomain
 
+// Tells SQLite to make its own copy of the bound data during the bind call,
+// so the source buffer's lifetime doesn't have to outlive sqlite3_step. The
+// default (nil) is SQLITE_STATIC, which is unsafe when the source is an
+// autoreleased NSString.utf8String buffer or a transient Swift String.
+private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
 /// SQLite database manager for Foodle's local persistence.
 public final class Database: @unchecked Sendable {
     private static let appGroupIdentifier = BundleIdentifiers.appGroup
@@ -17,7 +23,7 @@ public final class Database: @unchecked Sendable {
     private let path: String
     public var filePath: String { path }
 
-    public static let schemaVersion = 9
+    public static let schemaVersion = 10
 
     public init(path: String? = nil) throws {
         if let path = path {
@@ -56,6 +62,11 @@ public final class Database: @unchecked Sendable {
             throw FoodleError.databaseError(detail: "Could not open database: \(message)")
         }
         self.db = pointer
+
+        // Wait up to 5s on SQLITE_BUSY before failing. With the File Provider
+        // extension reading concurrently under WAL, lock contention is normal
+        // and short retries inside SQLite are cheaper than surfacing errors.
+        sqlite3_busy_timeout(pointer, 5000)
 
         // Enable WAL mode for better concurrent performance
         try execute("PRAGMA journal_mode = WAL")
@@ -204,7 +215,7 @@ public final class Database: @unchecked Sendable {
 
         try execute("""
             CREATE TABLE IF NOT EXISTS pending_deletions (
-                item_id TEXT NOT NULL,
+                item_id TEXT PRIMARY KEY,
                 deleted_at REAL NOT NULL DEFAULT (strftime('%s', 'now'))
             )
         """)
@@ -314,6 +325,22 @@ public final class Database: @unchecked Sendable {
             logger.info("Migrated database schema to version 9 (fixed tag data encoding)")
         }
 
+        if currentVersion < 10 {
+            // pending_deletions originally allowed duplicate item_id rows, so INSERT OR
+            // IGNORE could not dedupe and the table grew unbounded on repeated syncs.
+            // Rebuild it with item_id as PRIMARY KEY.
+            try execute("""
+                CREATE TABLE pending_deletions_new (
+                    item_id TEXT PRIMARY KEY,
+                    deleted_at REAL NOT NULL DEFAULT (strftime('%s', 'now'))
+                )
+            """)
+            try execute("INSERT OR IGNORE INTO pending_deletions_new SELECT item_id, deleted_at FROM pending_deletions")
+            try execute("DROP TABLE pending_deletions")
+            try execute("ALTER TABLE pending_deletions_new RENAME TO pending_deletions")
+            logger.info("Migrated database schema to version 10 (pending_deletions dedupe)")
+        }
+
         try execute("PRAGMA user_version = \(Self.schemaVersion)")
     }
 
@@ -337,7 +364,7 @@ public final class Database: @unchecked Sendable {
                 )
                 defer { sqlite3_finalize(tagStmt) }
                 sqlite3_bind_int64(tagStmt, 1, Int64(key.courseID))
-                sqlite3_bind_text(tagStmt, 2, (key.siteID as NSString).utf8String, -1, nil)
+                sqlite3_bind_text(tagStmt, 2, (key.siteID as NSString).utf8String, -1, SQLITE_TRANSIENT)
 
                 var tags: [FinderTag] = []
                 while sqlite3_step(tagStmt) == SQLITE_ROW {
@@ -353,11 +380,11 @@ public final class Database: @unchecked Sendable {
                 let updateStmt = try prepareStatement("UPDATE items SET tag_data = ? WHERE id = ?")
                 defer { sqlite3_finalize(updateStmt) }
                 if let td = tagData {
-                    sqlite3_bind_blob(updateStmt, 1, (td as NSData).bytes, Int32(td.count), nil)
+                    sqlite3_bind_blob(updateStmt, 1, (td as NSData).bytes, Int32(td.count), SQLITE_TRANSIENT)
                 } else {
                     sqlite3_bind_null(updateStmt, 1)
                 }
-                sqlite3_bind_text(updateStmt, 2, (itemID as NSString).utf8String, -1, nil)
+                sqlite3_bind_text(updateStmt, 2, (itemID as NSString).utf8String, -1, SQLITE_TRANSIENT)
                 _ = sqlite3_step(updateStmt)
             }
         }
@@ -422,19 +449,19 @@ extension Database {
             let stmt = try prepareStatement(sql)
             defer { sqlite3_finalize(stmt) }
 
-            sqlite3_bind_text(stmt, 1, (site.id as NSString).utf8String, -1, nil)
-            sqlite3_bind_text(stmt, 2, (site.displayName as NSString).utf8String, -1, nil)
-            sqlite3_bind_text(stmt, 3, (site.baseURL.absoluteString as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(stmt, 1, (site.id as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(stmt, 2, (site.displayName as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(stmt, 3, (site.baseURL.absoluteString as NSString).utf8String, -1, SQLITE_TRANSIENT)
             sqlite3_bind_int(stmt, 4, site.capabilities.supportsWebServices ? 1 : 0)
             sqlite3_bind_int(stmt, 5, site.capabilities.supportsMobileAPI ? 1 : 0)
             sqlite3_bind_int(stmt, 6, site.capabilities.supportsFileDownload ? 1 : 0)
-            if let v = site.capabilities.moodleVersion { sqlite3_bind_text(stmt, 7, (v as NSString).utf8String, -1, nil) }
-            if let r = site.capabilities.moodleRelease { sqlite3_bind_text(stmt, 8, (r as NSString).utf8String, -1, nil) }
-            if let n = site.capabilities.siteName { sqlite3_bind_text(stmt, 9, (n as NSString).utf8String, -1, nil) }
+            if let v = site.capabilities.moodleVersion { sqlite3_bind_text(stmt, 7, (v as NSString).utf8String, -1, SQLITE_TRANSIENT) }
+            if let r = site.capabilities.moodleRelease { sqlite3_bind_text(stmt, 8, (r as NSString).utf8String, -1, SQLITE_TRANSIENT) }
+            if let n = site.capabilities.siteName { sqlite3_bind_text(stmt, 9, (n as NSString).utf8String, -1, SQLITE_TRANSIENT) }
             sqlite3_bind_int(stmt, 10, Int32(site.capabilities.loginType.rawValue))
-            if let l = site.capabilities.launchURL { sqlite3_bind_text(stmt, 11, (l as NSString).utf8String, -1, nil) }
-            if let w = site.capabilities.wwwroot { sqlite3_bind_text(stmt, 12, (w as NSString).utf8String, -1, nil) }
-            if let h = site.capabilities.httpswwwroot { sqlite3_bind_text(stmt, 13, (h as NSString).utf8String, -1, nil) }
+            if let l = site.capabilities.launchURL { sqlite3_bind_text(stmt, 11, (l as NSString).utf8String, -1, SQLITE_TRANSIENT) }
+            if let w = site.capabilities.wwwroot { sqlite3_bind_text(stmt, 12, (w as NSString).utf8String, -1, SQLITE_TRANSIENT) }
+            if let h = site.capabilities.httpswwwroot { sqlite3_bind_text(stmt, 13, (h as NSString).utf8String, -1, SQLITE_TRANSIENT) }
             sqlite3_bind_int(stmt, 14, site.capabilities.showLoginForm ? 1 : 0)
 
             let status = sqlite3_step(stmt)
@@ -454,7 +481,7 @@ extension Database {
         return try queue.sync {
             let stmt = try prepareStatement(sql)
             defer { sqlite3_finalize(stmt) }
-            sqlite3_bind_text(stmt, 1, (id as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(stmt, 1, (id as NSString).utf8String, -1, SQLITE_TRANSIENT)
 
             guard sqlite3_step(stmt) == SQLITE_ROW else { return nil }
 
@@ -495,10 +522,10 @@ extension Database {
             let stmt = try prepareStatement(sql)
             defer { sqlite3_finalize(stmt) }
 
-            sqlite3_bind_text(stmt, 1, (account.id as NSString).utf8String, -1, nil)
-            sqlite3_bind_text(stmt, 2, (account.siteID as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(stmt, 1, (account.id as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(stmt, 2, (account.siteID as NSString).utf8String, -1, SQLITE_TRANSIENT)
             if let uid = account.userID { sqlite3_bind_int64(stmt, 3, Int64(uid)) }
-            sqlite3_bind_text(stmt, 4, (String(describing: account.state) as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(stmt, 4, (String(describing: account.state) as NSString).utf8String, -1, SQLITE_TRANSIENT)
             if let sync = account.lastSyncDate { sqlite3_bind_double(stmt, 5, sync.timeIntervalSince1970) }
             sqlite3_bind_double(stmt, 6, account.createdAt.timeIntervalSince1970)
 
@@ -543,12 +570,12 @@ extension Database {
         try queue.sync {
             let deleteItems = try prepareStatement("DELETE FROM items WHERE site_id IN (SELECT site_id FROM accounts WHERE id = ?)")
             defer { sqlite3_finalize(deleteItems) }
-            sqlite3_bind_text(deleteItems, 1, (id as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(deleteItems, 1, (id as NSString).utf8String, -1, SQLITE_TRANSIENT)
             _ = sqlite3_step(deleteItems)
 
             let deleteAccount = try prepareStatement("DELETE FROM accounts WHERE id = ?")
             defer { sqlite3_finalize(deleteAccount) }
-            sqlite3_bind_text(deleteAccount, 1, (id as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(deleteAccount, 1, (id as NSString).utf8String, -1, SQLITE_TRANSIENT)
             _ = sqlite3_step(deleteAccount)
         }
     }
@@ -579,38 +606,45 @@ extension Database {
         """
         try queue.sync {
             try executeUnsafe("BEGIN TRANSACTION")
-            for course in courses {
-                let stmt = try prepareStatement(sql)
-                defer { sqlite3_finalize(stmt) }
+            do {
+                for course in courses {
+                    let stmt = try prepareStatement(sql)
+                    defer { sqlite3_finalize(stmt) }
 
-                sqlite3_bind_int64(stmt, 1, Int64(course.id))
-                sqlite3_bind_text(stmt, 2, (course.siteID as NSString).utf8String, -1, nil)
-                sqlite3_bind_text(stmt, 3, (course.shortName as NSString).utf8String, -1, nil)
-                sqlite3_bind_text(stmt, 4, (course.fullName as NSString).utf8String, -1, nil)
-                if let s = course.summary { sqlite3_bind_text(stmt, 5, (s as NSString).utf8String, -1, nil) }
-                if let c = course.categoryID { sqlite3_bind_int64(stmt, 6, Int64(c)) }
-                if let d = course.startDate { sqlite3_bind_double(stmt, 7, d.timeIntervalSince1970) }
-                if let d = course.endDate { sqlite3_bind_double(stmt, 8, d.timeIntervalSince1970) }
-                if let d = course.lastAccessed { sqlite3_bind_double(stmt, 9, d.timeIntervalSince1970) }
-                sqlite3_bind_int(stmt, 10, course.visible ? 1 : 0)
-                let subscriptionState = course.isSyncEnabled
-                    ? CourseSubscriptionState.discovered.rawValue
-                    : CourseSubscriptionState.unsubscribed.rawValue
-                sqlite3_bind_text(stmt, 11, (subscriptionState as NSString).utf8String, -1, nil)
-                if let cfn = course.customFolderName {
-                    sqlite3_bind_text(stmt, 12, (cfn as NSString).utf8String, -1, nil)
-                } else {
-                    sqlite3_bind_null(stmt, 12)
-                }
-                if let cin = course.customIconName {
-                    sqlite3_bind_text(stmt, 13, (cin as NSString).utf8String, -1, nil)
-                } else {
-                    sqlite3_bind_null(stmt, 13)
-                }
+                    sqlite3_bind_int64(stmt, 1, Int64(course.id))
+                    sqlite3_bind_text(stmt, 2, (course.siteID as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                    sqlite3_bind_text(stmt, 3, (course.shortName as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                    sqlite3_bind_text(stmt, 4, (course.fullName as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                    if let s = course.summary { sqlite3_bind_text(stmt, 5, (s as NSString).utf8String, -1, SQLITE_TRANSIENT) }
+                    if let c = course.categoryID { sqlite3_bind_int64(stmt, 6, Int64(c)) }
+                    if let d = course.startDate { sqlite3_bind_double(stmt, 7, d.timeIntervalSince1970) }
+                    if let d = course.endDate { sqlite3_bind_double(stmt, 8, d.timeIntervalSince1970) }
+                    if let d = course.lastAccessed { sqlite3_bind_double(stmt, 9, d.timeIntervalSince1970) }
+                    sqlite3_bind_int(stmt, 10, course.visible ? 1 : 0)
+                    let subscriptionState = course.isSyncEnabled
+                        ? CourseSubscriptionState.discovered.rawValue
+                        : CourseSubscriptionState.unsubscribed.rawValue
+                    sqlite3_bind_text(stmt, 11, (subscriptionState as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                    if let cfn = course.customFolderName {
+                        sqlite3_bind_text(stmt, 12, (cfn as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                    } else {
+                        sqlite3_bind_null(stmt, 12)
+                    }
+                    if let cin = course.customIconName {
+                        sqlite3_bind_text(stmt, 13, (cin as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                    } else {
+                        sqlite3_bind_null(stmt, 13)
+                    }
 
-                _ = sqlite3_step(stmt)
+                    guard sqlite3_step(stmt) == SQLITE_DONE else {
+                        throw FoodleError.databaseError(detail: "saveCourses step failed: \(String(cString: sqlite3_errmsg(db)))")
+                    }
+                }
+                try executeUnsafe("COMMIT")
+            } catch {
+                try? executeUnsafe("ROLLBACK")
+                throw error
             }
-            try executeUnsafe("COMMIT")
         }
     }
 
@@ -619,7 +653,7 @@ extension Database {
         return try queue.sync {
             let stmt = try prepareStatement(sql)
             defer { sqlite3_finalize(stmt) }
-            sqlite3_bind_text(stmt, 1, (siteID as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(stmt, 1, (siteID as NSString).utf8String, -1, SQLITE_TRANSIENT)
 
             var courses: [MoodleCourse] = []
             while sqlite3_step(stmt) == SQLITE_ROW {
@@ -666,9 +700,9 @@ extension Database {
         try queue.sync {
             let stmt = try prepareStatement(sql)
             defer { sqlite3_finalize(stmt) }
-            sqlite3_bind_text(stmt, 1, (state.rawValue as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(stmt, 1, (state.rawValue as NSString).utf8String, -1, SQLITE_TRANSIENT)
             sqlite3_bind_int(stmt, 2, Int32(courseID))
-            sqlite3_bind_text(stmt, 3, (siteID as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(stmt, 3, (siteID as NSString).utf8String, -1, SQLITE_TRANSIENT)
             _ = sqlite3_step(stmt)
         }
     }
@@ -680,12 +714,12 @@ extension Database {
             defer { sqlite3_finalize(stmt) }
 
             if let name = customName, !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                sqlite3_bind_text(stmt, 1, (name as NSString).utf8String, -1, nil)
+                sqlite3_bind_text(stmt, 1, (name as NSString).utf8String, -1, SQLITE_TRANSIENT)
             } else {
                 sqlite3_bind_null(stmt, 1)
             }
             sqlite3_bind_int64(stmt, 2, Int64(courseID))
-            sqlite3_bind_text(stmt, 3, (siteID as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(stmt, 3, (siteID as NSString).utf8String, -1, SQLITE_TRANSIENT)
 
             let status = sqlite3_step(stmt)
             guard status == SQLITE_DONE else {
@@ -700,12 +734,12 @@ extension Database {
             defer { sqlite3_finalize(stmt) }
 
             if let name = iconName, !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                sqlite3_bind_text(stmt, 1, (name as NSString).utf8String, -1, nil)
+                sqlite3_bind_text(stmt, 1, (name as NSString).utf8String, -1, SQLITE_TRANSIENT)
             } else {
                 sqlite3_bind_null(stmt, 1)
             }
             sqlite3_bind_int64(stmt, 2, Int64(courseID))
-            sqlite3_bind_text(stmt, 3, (siteID as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(stmt, 3, (siteID as NSString).utf8String, -1, SQLITE_TRANSIENT)
 
             let status = sqlite3_step(stmt)
             guard status == SQLITE_DONE else {
@@ -721,28 +755,34 @@ extension Database {
     public func saveCourseTags(_ tags: [FinderTag], courseID: Int, siteID: String) throws {
         try queue.sync {
             try executeUnsafe("BEGIN TRANSACTION")
+            do {
+                let deleteSQL = "DELETE FROM course_tags WHERE course_id = ? AND site_id = ?"
+                let deleteStmt = try prepareStatement(deleteSQL)
+                defer { sqlite3_finalize(deleteStmt) }
+                sqlite3_bind_int64(deleteStmt, 1, Int64(courseID))
+                sqlite3_bind_text(deleteStmt, 2, (siteID as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                guard sqlite3_step(deleteStmt) == SQLITE_DONE else {
+                    throw FoodleError.databaseError(detail: "saveCourseTags delete failed: \(String(cString: sqlite3_errmsg(db)))")
+                }
 
-            // Remove existing tags for this course
-            let deleteSQL = "DELETE FROM course_tags WHERE course_id = ? AND site_id = ?"
-            let deleteStmt = try prepareStatement(deleteSQL)
-            defer { sqlite3_finalize(deleteStmt) }
-            sqlite3_bind_int64(deleteStmt, 1, Int64(courseID))
-            sqlite3_bind_text(deleteStmt, 2, (siteID as NSString).utf8String, -1, nil)
-            _ = sqlite3_step(deleteStmt)
+                let insertSQL = "INSERT INTO course_tags (course_id, site_id, tag_name, tag_color) VALUES (?, ?, ?, ?)"
+                for tag in tags {
+                    let stmt = try prepareStatement(insertSQL)
+                    defer { sqlite3_finalize(stmt) }
+                    sqlite3_bind_int64(stmt, 1, Int64(courseID))
+                    sqlite3_bind_text(stmt, 2, (siteID as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                    sqlite3_bind_text(stmt, 3, (tag.name as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                    sqlite3_bind_int(stmt, 4, Int32(tag.color.rawValue))
+                    guard sqlite3_step(stmt) == SQLITE_DONE else {
+                        throw FoodleError.databaseError(detail: "saveCourseTags insert failed: \(String(cString: sqlite3_errmsg(db)))")
+                    }
+                }
 
-            // Insert new tags
-            let insertSQL = "INSERT INTO course_tags (course_id, site_id, tag_name, tag_color) VALUES (?, ?, ?, ?)"
-            for tag in tags {
-                let stmt = try prepareStatement(insertSQL)
-                defer { sqlite3_finalize(stmt) }
-                sqlite3_bind_int64(stmt, 1, Int64(courseID))
-                sqlite3_bind_text(stmt, 2, (siteID as NSString).utf8String, -1, nil)
-                sqlite3_bind_text(stmt, 3, (tag.name as NSString).utf8String, -1, nil)
-                sqlite3_bind_int(stmt, 4, Int32(tag.color.rawValue))
-                _ = sqlite3_step(stmt)
+                try executeUnsafe("COMMIT")
+            } catch {
+                try? executeUnsafe("ROLLBACK")
+                throw error
             }
-
-            try executeUnsafe("COMMIT")
         }
     }
 
@@ -752,7 +792,7 @@ extension Database {
             let stmt = try prepareStatement(sql)
             defer { sqlite3_finalize(stmt) }
             sqlite3_bind_int64(stmt, 1, Int64(courseID))
-            sqlite3_bind_text(stmt, 2, (siteID as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(stmt, 2, (siteID as NSString).utf8String, -1, SQLITE_TRANSIENT)
 
             var tags: [FinderTag] = []
             while sqlite3_step(stmt) == SQLITE_ROW {
@@ -770,7 +810,7 @@ extension Database {
         return try queue.sync {
             let stmt = try prepareStatement(sql)
             defer { sqlite3_finalize(stmt) }
-            sqlite3_bind_text(stmt, 1, (siteID as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(stmt, 1, (siteID as NSString).utf8String, -1, SQLITE_TRANSIENT)
 
             var result: [Int: [FinderTag]] = [:]
             while sqlite3_step(stmt) == SQLITE_ROW {
@@ -797,36 +837,43 @@ extension Database {
         """
         try queue.sync {
             try executeUnsafe("BEGIN TRANSACTION")
-            for item in items {
-                let stmt = try prepareStatement(sql)
-                defer { sqlite3_finalize(stmt) }
+            do {
+                for item in items {
+                    let stmt = try prepareStatement(sql)
+                    defer { sqlite3_finalize(stmt) }
 
-                sqlite3_bind_text(stmt, 1, (item.id as NSString).utf8String, -1, nil)
-                if let p = item.parentID { sqlite3_bind_text(stmt, 2, (p as NSString).utf8String, -1, nil) }
-                sqlite3_bind_text(stmt, 3, (item.siteID as NSString).utf8String, -1, nil)
-                sqlite3_bind_int64(stmt, 4, Int64(item.courseID))
-                sqlite3_bind_int64(stmt, 5, Int64(item.remoteID))
-                sqlite3_bind_text(stmt, 6, (item.filename as NSString).utf8String, -1, nil)
-                sqlite3_bind_int(stmt, 7, item.isDirectory ? 1 : 0)
-                if let ct = item.contentType { sqlite3_bind_text(stmt, 8, (ct as NSString).utf8String, -1, nil) }
-                sqlite3_bind_int64(stmt, 9, item.fileSize)
-                if let d = item.creationDate { sqlite3_bind_double(stmt, 10, d.timeIntervalSince1970) }
-                if let d = item.modificationDate { sqlite3_bind_double(stmt, 11, d.timeIntervalSince1970) }
-                sqlite3_bind_text(stmt, 12, (item.syncState.rawValue as NSString).utf8String, -1, nil)
-                sqlite3_bind_int(stmt, 13, item.isPinned ? 1 : 0)
-                if let lp = item.localPath { sqlite3_bind_text(stmt, 14, (lp as NSString).utf8String, -1, nil) }
-                if let ru = item.remoteURL { sqlite3_bind_text(stmt, 15, (ru.absoluteString as NSString).utf8String, -1, nil) }
-                if let cv = item.contentVersion { sqlite3_bind_text(stmt, 16, (cv as NSString).utf8String, -1, nil) }
-                if let td = item.tagData {
-                    sqlite3_bind_blob(stmt, 17, (td as NSData).bytes, Int32(td.count), nil)
-                } else {
-                    sqlite3_bind_null(stmt, 17)
+                    sqlite3_bind_text(stmt, 1, (item.id as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                    if let p = item.parentID { sqlite3_bind_text(stmt, 2, (p as NSString).utf8String, -1, SQLITE_TRANSIENT) }
+                    sqlite3_bind_text(stmt, 3, (item.siteID as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                    sqlite3_bind_int64(stmt, 4, Int64(item.courseID))
+                    sqlite3_bind_int64(stmt, 5, Int64(item.remoteID))
+                    sqlite3_bind_text(stmt, 6, (item.filename as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                    sqlite3_bind_int(stmt, 7, item.isDirectory ? 1 : 0)
+                    if let ct = item.contentType { sqlite3_bind_text(stmt, 8, (ct as NSString).utf8String, -1, SQLITE_TRANSIENT) }
+                    sqlite3_bind_int64(stmt, 9, item.fileSize)
+                    if let d = item.creationDate { sqlite3_bind_double(stmt, 10, d.timeIntervalSince1970) }
+                    if let d = item.modificationDate { sqlite3_bind_double(stmt, 11, d.timeIntervalSince1970) }
+                    sqlite3_bind_text(stmt, 12, (item.syncState.rawValue as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                    sqlite3_bind_int(stmt, 13, item.isPinned ? 1 : 0)
+                    if let lp = item.localPath { sqlite3_bind_text(stmt, 14, (lp as NSString).utf8String, -1, SQLITE_TRANSIENT) }
+                    if let ru = item.remoteURL { sqlite3_bind_text(stmt, 15, (ru.absoluteString as NSString).utf8String, -1, SQLITE_TRANSIENT) }
+                    if let cv = item.contentVersion { sqlite3_bind_text(stmt, 16, (cv as NSString).utf8String, -1, SQLITE_TRANSIENT) }
+                    if let td = item.tagData {
+                        sqlite3_bind_blob(stmt, 17, (td as NSData).bytes, Int32(td.count), SQLITE_TRANSIENT)
+                    } else {
+                        sqlite3_bind_null(stmt, 17)
+                    }
+                    sqlite3_bind_int(stmt, 18, item.isLocal ? 1 : 0)
+
+                    guard sqlite3_step(stmt) == SQLITE_DONE else {
+                        throw FoodleError.databaseError(detail: "saveItems step failed: \(String(cString: sqlite3_errmsg(db)))")
+                    }
                 }
-                sqlite3_bind_int(stmt, 18, item.isLocal ? 1 : 0)
-
-                _ = sqlite3_step(stmt)
+                try executeUnsafe("COMMIT")
+            } catch {
+                try? executeUnsafe("ROLLBACK")
+                throw error
             }
-            try executeUnsafe("COMMIT")
         }
     }
 
@@ -835,7 +882,7 @@ extension Database {
             let stmt: OpaquePointer
             if let parentID = parentID {
                 stmt = try prepareStatement("SELECT * FROM items WHERE parent_id = ? ORDER BY is_directory DESC, filename")
-                sqlite3_bind_text(stmt, 1, (parentID as NSString).utf8String, -1, nil)
+                sqlite3_bind_text(stmt, 1, (parentID as NSString).utf8String, -1, SQLITE_TRANSIENT)
             } else {
                 stmt = try prepareStatement("SELECT * FROM items WHERE parent_id IS NULL ORDER BY is_directory DESC, filename")
             }
@@ -849,7 +896,7 @@ extension Database {
         return try queue.sync {
             let stmt = try prepareStatement(sql)
             defer { sqlite3_finalize(stmt) }
-            sqlite3_bind_text(stmt, 1, (id as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(stmt, 1, (id as NSString).utf8String, -1, SQLITE_TRANSIENT)
 
             guard sqlite3_step(stmt) == SQLITE_ROW else { return nil }
             return readItem(from: stmt)
@@ -861,7 +908,7 @@ extension Database {
         return try queue.sync {
             let stmt = try prepareStatement(sql)
             defer { sqlite3_finalize(stmt) }
-            sqlite3_bind_text(stmt, 1, (siteID as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(stmt, 1, (siteID as NSString).utf8String, -1, SQLITE_TRANSIENT)
             return try readItems(from: stmt)
         }
     }
@@ -871,8 +918,8 @@ extension Database {
         try queue.sync {
             let stmt = try prepareStatement(sql)
             defer { sqlite3_finalize(stmt) }
-            sqlite3_bind_text(stmt, 1, (filename as NSString).utf8String, -1, nil)
-            sqlite3_bind_text(stmt, 2, (id as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(stmt, 1, (filename as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(stmt, 2, (id as NSString).utf8String, -1, SQLITE_TRANSIENT)
             let status = sqlite3_step(stmt)
             guard status == SQLITE_DONE else {
                 throw FoodleError.databaseError(detail: "Failed to update item filename")
@@ -886,11 +933,11 @@ extension Database {
             let stmt = try prepareStatement(sql)
             defer { sqlite3_finalize(stmt) }
             if let td = tagData {
-                sqlite3_bind_blob(stmt, 1, (td as NSData).bytes, Int32(td.count), nil)
+                sqlite3_bind_blob(stmt, 1, (td as NSData).bytes, Int32(td.count), SQLITE_TRANSIENT)
             } else {
                 sqlite3_bind_null(stmt, 1)
             }
-            sqlite3_bind_text(stmt, 2, (id as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(stmt, 2, (id as NSString).utf8String, -1, SQLITE_TRANSIENT)
             let status = sqlite3_step(stmt)
             guard status == SQLITE_DONE else {
                 throw FoodleError.databaseError(detail: "Failed to update item tag data")
@@ -908,12 +955,12 @@ extension Database {
         try queue.sync {
             let stmt = try prepareStatement(sql)
             defer { sqlite3_finalize(stmt) }
-            sqlite3_bind_text(stmt, 1, (state.rawValue as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(stmt, 1, (state.rawValue as NSString).utf8String, -1, SQLITE_TRANSIENT)
             if let path = localPath {
-                sqlite3_bind_text(stmt, 2, (path as NSString).utf8String, -1, nil)
-                sqlite3_bind_text(stmt, 3, (id as NSString).utf8String, -1, nil)
+                sqlite3_bind_text(stmt, 2, (path as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                sqlite3_bind_text(stmt, 3, (id as NSString).utf8String, -1, SQLITE_TRANSIENT)
             } else {
-                sqlite3_bind_text(stmt, 2, (id as NSString).utf8String, -1, nil)
+                sqlite3_bind_text(stmt, 2, (id as NSString).utf8String, -1, SQLITE_TRANSIENT)
             }
             _ = sqlite3_step(stmt)
         }
@@ -925,7 +972,7 @@ extension Database {
             let stmt = try prepareStatement(sql)
             defer { sqlite3_finalize(stmt) }
             sqlite3_bind_int(stmt, 1, isPinned ? 1 : 0)
-            sqlite3_bind_text(stmt, 2, (id as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(stmt, 2, (id as NSString).utf8String, -1, SQLITE_TRANSIENT)
             let status = sqlite3_step(stmt)
             guard status == SQLITE_DONE else {
                 throw FoodleError.databaseError(detail: "Failed to update item pinned state")
@@ -946,43 +993,117 @@ extension Database {
         return try queue.sync {
             let stmt = try prepareStatement(sql)
             defer { sqlite3_finalize(stmt) }
-            sqlite3_bind_text(stmt, 1, (siteID as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(stmt, 1, (siteID as NSString).utf8String, -1, SQLITE_TRANSIENT)
             return try readItems(from: stmt)
         }
     }
 
     public func deleteItems(courseID: Int, siteID: String) throws {
         try queue.sync {
-            // Clear stale pending deletions from previous cycles before recording new ones.
-            try executeUnsafe("DELETE FROM pending_deletions")
-            // Record IDs for the File Provider to report as deletions (skip local items).
-            let insertStmt = try prepareStatement("INSERT INTO pending_deletions (item_id) SELECT id FROM items WHERE course_id = ? AND site_id = ? AND is_local = 0")
-            defer { sqlite3_finalize(insertStmt) }
-            sqlite3_bind_int(insertStmt, 1, Int32(courseID))
-            sqlite3_bind_text(insertStmt, 2, (siteID as NSString).utf8String, -1, nil)
-            _ = sqlite3_step(insertStmt)
+            try executeUnsafe("BEGIN TRANSACTION")
+            do {
+                // Record IDs for the File Provider to report as deletions (skip local items).
+                // Append to any pending deletions from prior cycles that haven't drained yet —
+                // do NOT wipe the table blindly or earlier course deletions would be lost.
+                let insertStmt = try prepareStatement("INSERT OR IGNORE INTO pending_deletions (item_id) SELECT id FROM items WHERE course_id = ? AND site_id = ? AND is_local = 0")
+                defer { sqlite3_finalize(insertStmt) }
+                sqlite3_bind_int(insertStmt, 1, Int32(courseID))
+                sqlite3_bind_text(insertStmt, 2, (siteID as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                guard sqlite3_step(insertStmt) == SQLITE_DONE else {
+                    throw FoodleError.databaseError(detail: "deleteItems pending insert failed")
+                }
 
-            let deleteStmt = try prepareStatement("DELETE FROM items WHERE course_id = ? AND site_id = ? AND is_local = 0")
-            defer { sqlite3_finalize(deleteStmt) }
-            sqlite3_bind_int(deleteStmt, 1, Int32(courseID))
-            sqlite3_bind_text(deleteStmt, 2, (siteID as NSString).utf8String, -1, nil)
-            _ = sqlite3_step(deleteStmt)
+                let deleteStmt = try prepareStatement("DELETE FROM items WHERE course_id = ? AND site_id = ? AND is_local = 0")
+                defer { sqlite3_finalize(deleteStmt) }
+                sqlite3_bind_int(deleteStmt, 1, Int32(courseID))
+                sqlite3_bind_text(deleteStmt, 2, (siteID as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                guard sqlite3_step(deleteStmt) == SQLITE_DONE else {
+                    throw FoodleError.databaseError(detail: "deleteItems delete failed")
+                }
+                try executeUnsafe("COMMIT")
+            } catch {
+                try? executeUnsafe("ROLLBACK")
+                throw error
+            }
         }
     }
 
     public func deleteAllItems(siteID: String) throws {
         try queue.sync {
-            try executeUnsafe("DELETE FROM pending_deletions")
+            try executeUnsafe("BEGIN TRANSACTION")
+            do {
+                let insertStmt = try prepareStatement("INSERT OR IGNORE INTO pending_deletions (item_id) SELECT id FROM items WHERE site_id = ? AND is_local = 0")
+                defer { sqlite3_finalize(insertStmt) }
+                sqlite3_bind_text(insertStmt, 1, (siteID as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                guard sqlite3_step(insertStmt) == SQLITE_DONE else {
+                    throw FoodleError.databaseError(detail: "deleteAllItems pending insert failed")
+                }
 
-            let insertStmt = try prepareStatement("INSERT INTO pending_deletions (item_id) SELECT id FROM items WHERE site_id = ? AND is_local = 0")
-            defer { sqlite3_finalize(insertStmt) }
-            sqlite3_bind_text(insertStmt, 1, (siteID as NSString).utf8String, -1, nil)
-            _ = sqlite3_step(insertStmt)
+                let deleteStmt = try prepareStatement("DELETE FROM items WHERE site_id = ? AND is_local = 0")
+                defer { sqlite3_finalize(deleteStmt) }
+                sqlite3_bind_text(deleteStmt, 1, (siteID as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                guard sqlite3_step(deleteStmt) == SQLITE_DONE else {
+                    throw FoodleError.databaseError(detail: "deleteAllItems delete failed")
+                }
+                try executeUnsafe("COMMIT")
+            } catch {
+                try? executeUnsafe("ROLLBACK")
+                throw error
+            }
+        }
+    }
 
-            let deleteStmt = try prepareStatement("DELETE FROM items WHERE site_id = ? AND is_local = 0")
-            defer { sqlite3_finalize(deleteStmt) }
-            sqlite3_bind_text(deleteStmt, 1, (siteID as NSString).utf8String, -1, nil)
-            _ = sqlite3_step(deleteStmt)
+    /// Delete the given items (and their descendants) and record a tombstone
+    /// in `pending_deletions` so the File Provider extension can report the
+    /// deletion to Finder on the next change enumeration. All work happens in
+    /// a single transaction so partial failures don't leak rows.
+    public func deleteItemsWithTombstone(ids: [String]) throws {
+        guard !ids.isEmpty else { return }
+        try queue.sync {
+            try executeUnsafe("BEGIN TRANSACTION")
+            do {
+                var idsToDelete = Set(ids)
+                var frontier = Array(ids)
+
+                while !frontier.isEmpty {
+                    var nextFrontier: [String] = []
+                    let childStmt = try prepareStatement("SELECT id FROM items WHERE parent_id = ?")
+                    defer { sqlite3_finalize(childStmt) }
+                    for parentID in frontier {
+                        sqlite3_reset(childStmt)
+                        sqlite3_bind_text(childStmt, 1, (parentID as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                        while sqlite3_step(childStmt) == SQLITE_ROW {
+                            let childID = String(cString: sqlite3_column_text(childStmt, 0))
+                            if idsToDelete.insert(childID).inserted {
+                                nextFrontier.append(childID)
+                            }
+                        }
+                    }
+                    frontier = nextFrontier
+                }
+
+                let tombstoneStmt = try prepareStatement("INSERT OR IGNORE INTO pending_deletions (item_id) VALUES (?)")
+                defer { sqlite3_finalize(tombstoneStmt) }
+                let deleteStmt = try prepareStatement("DELETE FROM items WHERE id = ?")
+                defer { sqlite3_finalize(deleteStmt) }
+
+                for itemID in idsToDelete {
+                    sqlite3_reset(tombstoneStmt)
+                    sqlite3_bind_text(tombstoneStmt, 1, (itemID as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                    guard sqlite3_step(tombstoneStmt) == SQLITE_DONE else {
+                        throw FoodleError.databaseError(detail: "deleteItemsWithTombstone tombstone failed")
+                    }
+                    sqlite3_reset(deleteStmt)
+                    sqlite3_bind_text(deleteStmt, 1, (itemID as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                    guard sqlite3_step(deleteStmt) == SQLITE_DONE else {
+                        throw FoodleError.databaseError(detail: "deleteItemsWithTombstone delete failed")
+                    }
+                }
+                try executeUnsafe("COMMIT")
+            } catch {
+                try? executeUnsafe("ROLLBACK")
+                throw error
+            }
         }
     }
 
@@ -999,7 +1120,7 @@ extension Database {
                 for parentID in frontier {
                     let stmt = try prepareStatement("SELECT id FROM items WHERE parent_id = ?")
                     defer { sqlite3_finalize(stmt) }
-                    sqlite3_bind_text(stmt, 1, (parentID as NSString).utf8String, -1, nil)
+                    sqlite3_bind_text(stmt, 1, (parentID as NSString).utf8String, -1, SQLITE_TRANSIENT)
                     while sqlite3_step(stmt) == SQLITE_ROW {
                         let childID = String(cString: sqlite3_column_text(stmt, 0))
                         idsToDelete.append(childID)
@@ -1012,7 +1133,7 @@ extension Database {
             for itemID in idsToDelete {
                 let stmt = try prepareStatement("DELETE FROM items WHERE id = ?")
                 defer { sqlite3_finalize(stmt) }
-                sqlite3_bind_text(stmt, 1, (itemID as NSString).utf8String, -1, nil)
+                sqlite3_bind_text(stmt, 1, (itemID as NSString).utf8String, -1, SQLITE_TRANSIENT)
                 _ = sqlite3_step(stmt)
             }
         }
@@ -1033,6 +1154,31 @@ extension Database {
 
     public func clearPendingDeletions() throws {
         try execute("DELETE FROM pending_deletions")
+    }
+
+    /// Clear only the pending deletions whose IDs have been reported to the
+    /// File Provider observer. Removes them in a single transaction to avoid
+    /// re-reporting the same deletion on the next change enumeration.
+    public func clearPendingDeletions(ids: [String]) throws {
+        guard !ids.isEmpty else { return }
+        try queue.sync {
+            try executeUnsafe("BEGIN TRANSACTION")
+            do {
+                let stmt = try prepareStatement("DELETE FROM pending_deletions WHERE item_id = ?")
+                defer { sqlite3_finalize(stmt) }
+                for id in ids {
+                    sqlite3_reset(stmt)
+                    sqlite3_bind_text(stmt, 1, (id as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                    guard sqlite3_step(stmt) == SQLITE_DONE else {
+                        throw FoodleError.databaseError(detail: "clearPendingDeletions failed for \(id)")
+                    }
+                }
+                try executeUnsafe("COMMIT")
+            } catch {
+                try? executeUnsafe("ROLLBACK")
+                throw error
+            }
+        }
     }
 
     private func readItems(from stmt: OpaquePointer) throws -> [LocalItem] {
@@ -1092,7 +1238,7 @@ extension Database {
             defer { sqlite3_finalize(stmt) }
 
             sqlite3_bind_int64(stmt, 1, Int64(cursor.courseID))
-            sqlite3_bind_text(stmt, 2, (cursor.siteID as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(stmt, 2, (cursor.siteID as NSString).utf8String, -1, SQLITE_TRANSIENT)
             sqlite3_bind_double(stmt, 3, cursor.lastSyncDate.timeIntervalSince1970)
             if let lm = cursor.lastModified { sqlite3_bind_double(stmt, 4, lm.timeIntervalSince1970) }
             sqlite3_bind_int64(stmt, 5, Int64(cursor.itemCount))
@@ -1107,7 +1253,7 @@ extension Database {
             let stmt = try prepareStatement(sql)
             defer { sqlite3_finalize(stmt) }
             sqlite3_bind_int64(stmt, 1, Int64(courseID))
-            sqlite3_bind_text(stmt, 2, (siteID as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(stmt, 2, (siteID as NSString).utf8String, -1, SQLITE_TRANSIENT)
 
             guard sqlite3_step(stmt) == SQLITE_ROW else { return nil }
 
@@ -1126,7 +1272,7 @@ extension Database {
         return try queue.sync {
             let stmt = try prepareStatement(sql)
             defer { sqlite3_finalize(stmt) }
-            sqlite3_bind_text(stmt, 1, (siteID as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(stmt, 1, (siteID as NSString).utf8String, -1, SQLITE_TRANSIENT)
 
             var cursors: [SyncCursor] = []
             while sqlite3_step(stmt) == SQLITE_ROW {

--- a/Sources/Persistence/Database.swift
+++ b/Sources/Persistence/Database.swift
@@ -230,41 +230,6 @@ public final class Database: @unchecked Sendable {
         """)
         try execute("INSERT OR IGNORE INTO system_metadata (key, value) VALUES ('change_counter', 0)")
 
-        try execute("CREATE INDEX IF NOT EXISTS idx_items_updated_at ON items(updated_at)")
-        try execute("CREATE INDEX IF NOT EXISTS idx_pending_deletions_counter ON pending_deletions(deleted_at_counter)")
-
-        // Triggers that stamp items.updated_at and pending_deletions.deleted_at_counter
-        // with a monotonic global counter on every write. The `WHEN NEW.<col> = 0`
-        // guard skips already-stamped rows (e.g., during migration where we set the
-        // value explicitly) so the trigger doesn't recurse and doesn't re-stamp.
-        try execute("""
-            CREATE TRIGGER IF NOT EXISTS items_bump_after_insert
-            AFTER INSERT ON items
-            WHEN NEW.updated_at = 0
-            BEGIN
-                UPDATE system_metadata SET value = value + 1 WHERE key = 'change_counter';
-                UPDATE items SET updated_at = (SELECT value FROM system_metadata WHERE key = 'change_counter') WHERE id = NEW.id;
-            END
-        """)
-        try execute("""
-            CREATE TRIGGER IF NOT EXISTS items_bump_after_update
-            AFTER UPDATE OF parent_id, filename, file_size, sync_state, is_pinned, local_path, remote_url, content_version, tag_data, is_local, modification_date
-            ON items
-            BEGIN
-                UPDATE system_metadata SET value = value + 1 WHERE key = 'change_counter';
-                UPDATE items SET updated_at = (SELECT value FROM system_metadata WHERE key = 'change_counter') WHERE id = NEW.id;
-            END
-        """)
-        try execute("""
-            CREATE TRIGGER IF NOT EXISTS pending_deletions_bump_after_insert
-            AFTER INSERT ON pending_deletions
-            WHEN NEW.deleted_at_counter = 0
-            BEGIN
-                UPDATE system_metadata SET value = value + 1 WHERE key = 'change_counter';
-                UPDATE pending_deletions SET deleted_at_counter = (SELECT value FROM system_metadata WHERE key = 'change_counter') WHERE item_id = NEW.item_id;
-            END
-        """)
-
         try execute("""
             CREATE INDEX IF NOT EXISTS idx_items_parent ON items(parent_id)
         """)
@@ -1334,31 +1299,6 @@ extension Database {
 
     public func clearPendingDeletions() throws {
         try execute("DELETE FROM pending_deletions")
-    }
-
-    /// Clear only the pending deletions whose IDs have been reported to the
-    /// File Provider observer. Removes them in a single transaction to avoid
-    /// re-reporting the same deletion on the next change enumeration.
-    public func clearPendingDeletions(ids: [String]) throws {
-        guard !ids.isEmpty else { return }
-        try queue.sync {
-            try executeUnsafe("BEGIN TRANSACTION")
-            do {
-                let stmt = try prepareStatement("DELETE FROM pending_deletions WHERE item_id = ?")
-                defer { sqlite3_finalize(stmt) }
-                for id in ids {
-                    sqlite3_reset(stmt)
-                    sqlite3_bind_text(stmt, 1, (id as NSString).utf8String, -1, SQLITE_TRANSIENT)
-                    guard sqlite3_step(stmt) == SQLITE_DONE else {
-                        throw FoodleError.databaseError(detail: "clearPendingDeletions failed for \(id)")
-                    }
-                }
-                try executeUnsafe("COMMIT")
-            } catch {
-                try? executeUnsafe("ROLLBACK")
-                throw error
-            }
-        }
     }
 
     private func readItems(from stmt: OpaquePointer) throws -> [LocalItem] {

--- a/Sources/Persistence/Database.swift
+++ b/Sources/Persistence/Database.swift
@@ -1048,6 +1048,27 @@ extension Database {
         }
     }
 
+    /// Reset items stuck in the transient `.downloading` state back to
+    /// `.placeholder`. A download can't survive the process that started it, so
+    /// any `.downloading` row found at launch is stale and would otherwise show
+    /// a perpetual in-progress state. Returns the number of rows reset.
+    @discardableResult
+    public func resetStaleDownloads(siteID: String) throws -> Int {
+        try queue.sync {
+            let stmt = try prepareStatement(
+                "UPDATE items SET sync_state = ? WHERE site_id = ? AND sync_state = ?"
+            )
+            defer { sqlite3_finalize(stmt) }
+            sqlite3_bind_text(stmt, 1, (ItemSyncState.placeholder.rawValue as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(stmt, 2, (siteID as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(stmt, 3, (ItemSyncState.downloading.rawValue as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            guard sqlite3_step(stmt) == SQLITE_DONE else {
+                throw FoodleError.databaseError(detail: "Failed to reset stale downloads")
+            }
+            return Int(sqlite3_changes(db))
+        }
+    }
+
     public func updateItemPinned(id: String, isPinned: Bool) throws {
         let sql = "UPDATE items SET is_pinned = ? WHERE id = ?"
         try queue.sync {

--- a/Sources/SharedDomain/Errors/FoodleError.swift
+++ b/Sources/SharedDomain/Errors/FoodleError.swift
@@ -108,8 +108,12 @@ public enum FoodleError: Error, Sendable, LocalizedError {
 
     public var isRetryable: Bool {
         switch self {
-        case .networkUnavailable, .timeout, .requestFailed:
+        case .networkUnavailable, .timeout:
             return true
+        case .requestFailed(let statusCode, _):
+            // Only retry transient HTTP failures. 4xx is a client error and
+            // retrying just hammers the server without fixing anything.
+            return statusCode == 408 || statusCode == 429 || (500...599).contains(statusCode)
         case .tokenExpired, .tokenRefreshFailed:
             return false
         default:

--- a/Sources/SharedDomain/Errors/FoodleError.swift
+++ b/Sources/SharedDomain/Errors/FoodleError.swift
@@ -125,4 +125,17 @@ public enum FoodleError: Error, Sendable, LocalizedError {
         if case .cancelled = self { return true }
         return false
     }
+
+    /// Whether recovering from this error requires the user to sign in again.
+    /// These failures affect every authenticated request, so callers should
+    /// stop retrying and prompt the user to reconnect rather than surfacing a
+    /// generic error.
+    public var requiresReauthentication: Bool {
+        switch self {
+        case .tokenExpired, .tokenRefreshFailed, .authenticationRequired:
+            return true
+        default:
+            return false
+        }
+    }
 }

--- a/Sources/SharedDomain/Models/FileNameSanitizer.swift
+++ b/Sources/SharedDomain/Models/FileNameSanitizer.swift
@@ -8,7 +8,15 @@ import Foundation
 /// Sanitizes strings for use as file and folder names in Finder.
 public enum FileNameSanitizer {
     /// Characters forbidden in macOS filenames.
-    private static let forbiddenCharacters = CharacterSet(charactersIn: "/:\0")
+    /// Forward slash and NUL are kernel-level reserved on HFS/APFS; colon is
+    /// remapped to slash by Finder and breaks SMB/iCloud round-trips; backslash
+    /// is permitted by the filesystem but breaks plenty of clients; control
+    /// characters survive as garbage in Finder if not stripped.
+    private static let forbiddenCharacters: CharacterSet = {
+        var set = CharacterSet(charactersIn: "/:\\\0")
+        set.formUnion(.controlCharacters)
+        return set
+    }()
 
     /// Maximum filename length (HFS+/APFS limit is 255 UTF-8 bytes).
     private static let maxLength = 200
@@ -26,10 +34,8 @@ public enum FileNameSanitizer {
             .map { forbiddenCharacters.contains($0) ? "-" : String($0) }
             .joined()
 
-        // Collapse multiple dashes
-        while sanitized.contains("--") {
-            sanitized = sanitized.replacingOccurrences(of: "--", with: "-")
-        }
+        // Collapse multiple dashes (single pass — avoids O(n²) on adversarial input).
+        sanitized = collapseDashes(sanitized)
 
         // Remove leading dots (hidden files in UNIX)
         while sanitized.hasPrefix(".") {
@@ -39,24 +45,67 @@ public enum FileNameSanitizer {
         // Remove leading/trailing dashes
         sanitized = sanitized.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
 
-        // Fallback for empty names
-        if sanitized.isEmpty {
+        // Reserved single-/double-dot names map to Untitled.
+        if sanitized.isEmpty || sanitized == "." || sanitized == ".." {
             sanitized = "Untitled"
         }
 
-        // Truncate if too long
+        // Truncate if too long, preserving scalar boundaries so the result is
+        // always valid UTF-8 (slicing utf8 by byte count can land mid-scalar).
         if sanitized.utf8.count > maxLength {
-            if preserveExtension, let dotIndex = sanitized.lastIndex(of: ".") {
+            if preserveExtension,
+               let dotIndex = sanitized.lastIndex(of: "."),
+               looksLikeExtension(sanitized[dotIndex...]) {
                 let ext = String(sanitized[dotIndex...])
                 let stem = String(sanitized[..<dotIndex])
-                let maxStem = maxLength - ext.utf8.count
-                let truncated = String(stem.utf8.prefix(maxStem)) ?? stem.prefix(maxStem / 4).description
-                sanitized = truncated + ext
+                let maxStem = max(0, maxLength - ext.utf8.count)
+                sanitized = truncateByScalars(stem, maxBytes: maxStem) + ext
             } else {
-                sanitized = String(sanitized.utf8.prefix(maxLength)) ?? String(sanitized.prefix(maxLength / 4))
+                sanitized = truncateByScalars(sanitized, maxBytes: maxLength)
             }
         }
 
         return sanitized
+    }
+
+    /// Walk the scalar sequence accumulating UTF-8 bytes, stopping before
+    /// exceeding `maxBytes`. Always returns a valid UTF-8 string.
+    private static func truncateByScalars(_ s: String, maxBytes: Int) -> String {
+        var bytes = 0
+        var result = ""
+        result.reserveCapacity(min(maxBytes, s.utf8.count))
+        for scalar in s.unicodeScalars {
+            let scalarBytes = UTF8.width(scalar)
+            if bytes + scalarBytes > maxBytes { break }
+            bytes += scalarBytes
+            result.unicodeScalars.append(scalar)
+        }
+        return result
+    }
+
+    private static func collapseDashes(_ s: String) -> String {
+        var result = ""
+        result.reserveCapacity(s.count)
+        var lastWasDash = false
+        for ch in s {
+            if ch == "-" {
+                if !lastWasDash { result.append(ch) }
+                lastWasDash = true
+            } else {
+                result.append(ch)
+                lastWasDash = false
+            }
+        }
+        return result
+    }
+
+    /// Heuristic: only treat `.xyz` as an extension when xyz looks like a
+    /// real extension (1-6 alphanumeric chars). Otherwise a name like
+    /// "My.Course.Name" would lose part of its stem during truncation.
+    private static func looksLikeExtension(_ suffix: Substring) -> Bool {
+        guard suffix.first == "." else { return false }
+        let ext = suffix.dropFirst()
+        guard (1...6).contains(ext.count) else { return false }
+        return ext.allSatisfy { $0.isLetter || $0.isNumber }
     }
 }

--- a/Sources/SharedDomain/Models/FinderTag.swift
+++ b/Sources/SharedDomain/Models/FinderTag.swift
@@ -47,11 +47,26 @@ public struct FinderTag: Sendable, Codable, Equatable, Hashable {
         "\(name)\n\(color.rawValue)"
     }
 
-    /// Serialize an array of tags into NSKeyedArchiver data suitable for
-    /// NSFileProviderItem.tagData.
+    /// Serialize an array of tags into binary plist data suitable for
+    /// NSFileProviderItem.tagData and com.apple.metadata:_kMDItemUserTags.
     public static func tagData(from tags: [FinderTag]) -> Data? {
         guard !tags.isEmpty else { return nil }
-        let strings = tags.map(\.serialized) as NSArray
-        return try? NSKeyedArchiver.archivedData(withRootObject: strings, requiringSecureCoding: true)
+        let strings = tags.map(\.serialized)
+        return try? PropertyListSerialization.data(fromPropertyList: strings, format: .binary, options: 0)
+    }
+
+    /// Parse tags from binary plist tagData (as produced by Finder / File Provider).
+    public static func parseTags(from data: Data) -> [FinderTag] {
+        guard let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil),
+              let strings = plist as? [String] else {
+            return []
+        }
+        return strings.compactMap { string in
+            let parts = string.split(separator: "\n", maxSplits: 1)
+            guard let name = parts.first, !name.isEmpty else { return nil }
+            let colorIndex = parts.count > 1 ? Int(parts[1]) ?? 0 : 0
+            let color = Color(rawValue: colorIndex) ?? .none
+            return FinderTag(name: String(name), color: color)
+        }
     }
 }

--- a/Sources/SharedDomain/Models/MoodleSite.swift
+++ b/Sources/SharedDomain/Models/MoodleSite.swift
@@ -21,12 +21,30 @@ public struct MoodleSite: Sendable, Codable, Equatable, Identifiable {
 
     /// The web services endpoint for this site.
     public var webServiceURL: URL {
-        baseURL.appendingPathComponent("webservice/rest/server.php")
+        Self.appending(path: "webservice/rest/server.php", to: baseURL)
     }
 
     /// The token endpoint for this site.
     public var tokenURL: URL {
-        baseURL.appendingPathComponent("login/token.php")
+        Self.appending(path: "login/token.php", to: baseURL)
+    }
+
+    /// Append a service-relative path to a Moodle base URL, going through
+    /// URLComponents so any existing path is preserved correctly and a
+    /// trailing-slash mismatch on `baseURL` doesn't collapse the suffix.
+    /// Falls back to the simple appendingPathComponent on the (unreachable)
+    /// path where URLComponents can't be constructed.
+    private static func appending(path suffix: String, to base: URL) -> URL {
+        guard var components = URLComponents(url: base, resolvingAgainstBaseURL: false) else {
+            return base.appendingPathComponent(suffix)
+        }
+        var basePath = components.path
+        if basePath.hasSuffix("/") {
+            basePath.removeLast()
+        }
+        let trimmedSuffix = suffix.hasPrefix("/") ? String(suffix.dropFirst()) : suffix
+        components.path = basePath.isEmpty ? "/\(trimmedSuffix)" : "\(basePath)/\(trimmedSuffix)"
+        return components.url ?? base.appendingPathComponent(suffix)
     }
 
     /// The custom URL scheme used for SSO callbacks.

--- a/Sources/SyncEngine/SyncEngine.swift
+++ b/Sources/SyncEngine/SyncEngine.swift
@@ -38,8 +38,24 @@ public actor SyncEngine {
     // MARK: - Course Sync
 
     /// Sync all subscribed courses for a site.
-    public func syncAllCourses(site: MoodleSite, token: AuthToken, courses: [MoodleCourse]) async {
+    ///
+    /// Throws if a course fails with an authentication error (`tokenExpired`
+    /// etc.) — such failures affect every course, so we stop early and let the
+    /// caller prompt the user to reconnect. Per-course non-auth failures are
+    /// logged and the sync continues with the remaining courses.
+    public func syncAllCourses(site: MoodleSite, token: AuthToken, courses: [MoodleCourse]) async throws {
         logger.info("Starting sync for \(courses.count) courses on \(site.displayName, privacy: .public)")
+
+        // Reset progress up front so a re-sync doesn't briefly report the
+        // previous run's completion state to progress observers.
+        for course in courses {
+            syncProgress[course.id] = SyncProgress(
+                courseID: course.id,
+                totalItems: 0,
+                processedItems: 0,
+                state: .syncing
+            )
+        }
 
         for course in courses {
             guard activeTasks[course.id] == nil else {
@@ -55,8 +71,18 @@ public actor SyncEngine {
             do {
                 try await task.value
                 logger.info("Sync completed for course \(course.id, privacy: .public)")
+            } catch let error as FoodleError where error.requiresReauthentication {
+                logger.error("Authentication failed during sync of course \(course.id, privacy: .public) — aborting")
+                syncProgress[course.id]?.state = .stale
+                activeTasks[course.id] = nil
+                throw error
+            } catch is CancellationError {
+                activeTasks[course.id] = nil
+                throw CancellationError()
             } catch {
                 logger.error("Sync failed for course \(course.id): \(error.localizedDescription, privacy: .public)")
+                // Mark as no-longer-syncing so progress observers advance past it.
+                syncProgress[course.id]?.state = .stale
             }
 
             activeTasks[course.id] = nil

--- a/Sources/SyncEngine/SyncEngine.swift
+++ b/Sources/SyncEngine/SyncEngine.swift
@@ -74,8 +74,12 @@ public actor SyncEngine {
             state: .syncing
         )
 
+        try Task.checkCancellation()
+
         // Fetch remote content tree
         let sections = try await provider.fetchCourseContents(site: site, token: token, courseID: course.id)
+
+        try Task.checkCancellation()
 
         // Look up Finder tags for this course
         let courseTags = try database.fetchCourseTags(courseID: course.id, siteID: site.id)
@@ -132,18 +136,26 @@ public actor SyncEngine {
 
         syncProgress[course.id]?.totalItems = allItems.count
 
+        try Task.checkCancellation()
+
         // Diff against existing items
         let existingItems = try database.fetchAllItems(siteID: site.id).filter { $0.courseID == course.id && !$0.isLocal }
 
         let changes = diffItems(existing: existingItems, incoming: allItems)
 
+        try Task.checkCancellation()
+
         // Apply changes
         if !changes.added.isEmpty || !changes.modified.isEmpty {
             try database.saveItems(changes.added + changes.modified)
         }
-        for removed in changes.removed {
-            try database.updateItemSyncState(id: removed.id, state: .placeholder)
+        // Removed items: actually delete them and record tombstones so the
+        // File Provider extension can report the deletions to Finder.
+        if !changes.removed.isEmpty {
+            try database.deleteItemsWithTombstone(ids: changes.removed.map(\.id))
         }
+
+        try Task.checkCancellation()
 
         // Update sync cursor
         let cursor = SyncCursor(
@@ -175,8 +187,13 @@ public actor SyncEngine {
 
             for item in pending {
                 guard item.remoteURL != nil else { continue }
+                // Use item.id as the temp filename to avoid collisions between
+                // different items that share a basename (e.g. "Slides.pdf").
+                let pathExtension = (item.filename as NSString).pathExtension
+                let baseName = item.id.replacingOccurrences(of: "/", with: "_")
+                let tempFilename = pathExtension.isEmpty ? baseName : "\(baseName).\(pathExtension)"
                 let destination = FileManager.default.temporaryDirectory
-                    .appendingPathComponent(item.filename)
+                    .appendingPathComponent(tempFilename)
                 do {
                     try await downloadItem(
                         itemID: item.id,
@@ -374,6 +391,8 @@ public actor SyncEngine {
             try database.updateItemSyncState(id: itemID, state: .materialized, localPath: destination.path)
             logger.info("Downloaded item \(itemID, privacy: .public)")
         } catch {
+            // Don't leave a half-written file behind for the next download to trip on.
+            try? FileManager.default.removeItem(at: destination)
             try database.updateItemSyncState(id: itemID, state: .error)
             throw error
         }

--- a/Sources/SyncEngine/SyncEngine.swift
+++ b/Sources/SyncEngine/SyncEngine.swift
@@ -327,8 +327,9 @@ public actor SyncEngine {
 
         for (id, var item) in incomingByID {
             if let existing = existingByID[id] {
-                // Preserve user-set pin state across syncs
+                // Preserve user-set metadata across syncs
                 item.isPinned = existing.isPinned
+                item.tagData = existing.tagData
 
                 if existing.contentVersion != item.contentVersion ||
                    existing.fileSize != item.fileSize ||

--- a/Tests/NetworkingTests/MoodleClientTests.swift
+++ b/Tests/NetworkingTests/MoodleClientTests.swift
@@ -40,14 +40,31 @@ final class MoodleClientTests: XCTestCase {
         XCTAssertEqual(url2.absoluteString, "https://moodle.example.edu")
     }
 
-    func testAuthenticatedFileURL() {
+    func testAuthenticatedFileRequestKeepsTokenOutOfURL() {
         let client = MoodleClient()
         let token = AuthToken(token: "testtoken123")
         let fileURL = URL(string: "https://moodle.example.edu/pluginfile.php/123/mod_resource/content/1/file.pdf")!
 
-        let result = client.authenticatedFileURL(fileURL: fileURL, token: token)
+        let request = client.authenticatedFileRequest(fileURL: fileURL, token: token)
 
-        XCTAssertTrue(result.absoluteString.contains("token=testtoken123"))
+        // The URL must not contain the token in any form (query, fragment, path).
+        XCTAssertEqual(request.url, fileURL)
+        XCTAssertFalse(request.url?.absoluteString.contains("testtoken123") ?? true)
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/x-www-form-urlencoded")
+        let body = String(data: request.httpBody ?? Data(), encoding: .utf8)
+        XCTAssertEqual(body, "token=testtoken123")
+    }
+
+    func testAuthenticatedFileRequestEncodesSpecialTokenCharacters() {
+        let client = MoodleClient()
+        // Token contains characters that mustn't appear unescaped in a form body.
+        let token = AuthToken(token: "abc+def=&xyz")
+        let fileURL = URL(string: "https://moodle.example.edu/pluginfile.php/file.pdf")!
+
+        let request = client.authenticatedFileRequest(fileURL: fileURL, token: token)
+        let body = String(data: request.httpBody ?? Data(), encoding: .utf8)
+        XCTAssertEqual(body, "token=abc%2Bdef%3D%26xyz")
     }
 
     func testTokenResponseDecoding() throws {

--- a/Tests/PersistenceTests/DatabaseTests.swift
+++ b/Tests/PersistenceTests/DatabaseTests.swift
@@ -4,6 +4,7 @@
 // You may obtain a copy of the License in the LICENSE file at the root of this repository.
 
 import XCTest
+import SQLite3
 @testable import FoodlePersistence
 @testable import SharedDomain
 
@@ -324,6 +325,17 @@ final class DatabaseTests: XCTestCase {
 
     // MARK: - Change Counter / Sync Anchor
 
+    func testOpeningVersion10DatabaseMigratesChangeCounterColumns() throws {
+        database = nil
+        try? FileManager.default.removeItem(atPath: tempPath)
+        try createVersion10Database(at: tempPath)
+
+        database = try Database(path: tempPath)
+
+        try database.saveItems([makeItem(id: "migrated-item")])
+        XCTAssertGreaterThan(try database.currentChangeCounter(), 0)
+    }
+
     private func makeItem(id: String, parentID: String? = nil, courseID: Int = 1) -> LocalItem {
         LocalItem(
             id: id,
@@ -335,6 +347,120 @@ final class DatabaseTests: XCTestCase {
             isDirectory: false,
             syncState: .placeholder
         )
+    }
+
+    private func createVersion10Database(at path: String) throws {
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(path, &db), SQLITE_OK)
+        guard let db else {
+            throw NSError(
+                domain: "DatabaseTests",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Unable to open temporary SQLite database"]
+            )
+        }
+        defer { sqlite3_close(db) }
+
+        try executeRawSQL(db, """
+            CREATE TABLE sites (
+                id TEXT PRIMARY KEY,
+                display_name TEXT NOT NULL,
+                base_url TEXT NOT NULL,
+                supports_web_services INTEGER NOT NULL DEFAULT 0,
+                supports_mobile_api INTEGER NOT NULL DEFAULT 0,
+                supports_file_download INTEGER NOT NULL DEFAULT 0,
+                moodle_version TEXT,
+                moodle_release TEXT,
+                site_name TEXT,
+                created_at REAL NOT NULL DEFAULT (strftime('%s', 'now')),
+                login_type INTEGER NOT NULL DEFAULT 1,
+                launch_url TEXT,
+                wwwroot TEXT,
+                httpswwwroot TEXT,
+                show_login_form INTEGER NOT NULL DEFAULT 1
+            );
+            CREATE TABLE accounts (
+                id TEXT PRIMARY KEY,
+                site_id TEXT NOT NULL REFERENCES sites(id) ON DELETE CASCADE,
+                user_id INTEGER,
+                username TEXT,
+                full_name TEXT,
+                state TEXT NOT NULL DEFAULT 'disconnected',
+                last_sync_date REAL,
+                created_at REAL NOT NULL DEFAULT (strftime('%s', 'now'))
+            );
+            CREATE TABLE courses (
+                id INTEGER NOT NULL,
+                site_id TEXT NOT NULL,
+                short_name TEXT NOT NULL,
+                full_name TEXT NOT NULL,
+                summary TEXT,
+                category_id INTEGER,
+                start_date REAL,
+                end_date REAL,
+                last_accessed REAL,
+                visible INTEGER NOT NULL DEFAULT 1,
+                subscription_state TEXT NOT NULL DEFAULT 'discovered',
+                custom_folder_name TEXT,
+                custom_icon_name TEXT,
+                PRIMARY KEY (id, site_id)
+            );
+            CREATE TABLE items (
+                id TEXT PRIMARY KEY,
+                parent_id TEXT,
+                site_id TEXT NOT NULL,
+                course_id INTEGER NOT NULL,
+                remote_id INTEGER NOT NULL,
+                filename TEXT NOT NULL,
+                is_directory INTEGER NOT NULL DEFAULT 0,
+                content_type TEXT,
+                file_size INTEGER NOT NULL DEFAULT 0,
+                creation_date REAL,
+                modification_date REAL,
+                sync_state TEXT NOT NULL DEFAULT 'placeholder',
+                is_pinned INTEGER NOT NULL DEFAULT 0,
+                local_path TEXT,
+                remote_url TEXT,
+                content_version TEXT,
+                tag_data BLOB,
+                is_local INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE TABLE sync_cursors (
+                course_id INTEGER NOT NULL,
+                site_id TEXT NOT NULL,
+                last_sync_date REAL NOT NULL,
+                last_modified REAL,
+                item_count INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (course_id, site_id)
+            );
+            CREATE TABLE course_tags (
+                course_id INTEGER NOT NULL,
+                site_id TEXT NOT NULL,
+                tag_name TEXT NOT NULL,
+                tag_color INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (course_id, site_id, tag_name)
+            );
+            CREATE TABLE pending_deletions (
+                item_id TEXT PRIMARY KEY,
+                deleted_at REAL NOT NULL DEFAULT (strftime('%s', 'now'))
+            );
+            PRAGMA user_version = 10;
+        """)
+    }
+
+    private func executeRawSQL(_ db: OpaquePointer, _ sql: String) throws {
+        var errorMessage: UnsafeMutablePointer<CChar>?
+        let status = sqlite3_exec(db, sql, nil, nil, &errorMessage)
+        if status != SQLITE_OK {
+            let message = errorMessage.map { String(cString: $0) } ?? "Unknown SQLite error"
+            sqlite3_free(errorMessage)
+            XCTFail(message)
+            throw NSError(
+                domain: "DatabaseTests",
+                code: Int(status),
+                userInfo: [NSLocalizedDescriptionKey: message]
+            )
+        }
     }
 
     func testChangeCounterIncrementsOnItemInsert() throws {

--- a/Tests/PersistenceTests/DatabaseTests.swift
+++ b/Tests/PersistenceTests/DatabaseTests.swift
@@ -336,6 +336,22 @@ final class DatabaseTests: XCTestCase {
         XCTAssertGreaterThan(try database.currentChangeCounter(), 0)
     }
 
+    func testResetStaleDownloadsOnlyClearsDownloadingItems() throws {
+        try database.saveItems([
+            makeItem(id: "downloading-item"),
+            makeItem(id: "materialized-item"),
+        ])
+        try database.updateItemSyncState(id: "downloading-item", state: .downloading)
+        try database.updateItemSyncState(id: "materialized-item", state: .materialized)
+
+        let resetCount = try database.resetStaleDownloads(siteID: "site-1")
+
+        XCTAssertEqual(resetCount, 1)
+        XCTAssertEqual(try database.fetchItem(id: "downloading-item")?.syncState, .placeholder)
+        // Items in other states must be left untouched.
+        XCTAssertEqual(try database.fetchItem(id: "materialized-item")?.syncState, .materialized)
+    }
+
     private func makeItem(id: String, parentID: String? = nil, courseID: Int = 1) -> LocalItem {
         LocalItem(
             id: id,

--- a/Tests/PersistenceTests/DatabaseTests.swift
+++ b/Tests/PersistenceTests/DatabaseTests.swift
@@ -321,4 +321,64 @@ final class DatabaseTests: XCTestCase {
         let fetched = try database.fetchCourses(siteID: "site-1")
         XCTAssertTrue(fetched.isEmpty)
     }
+
+    // MARK: - Change Counter / Sync Anchor
+
+    private func makeItem(id: String, parentID: String? = nil, courseID: Int = 1) -> LocalItem {
+        LocalItem(
+            id: id,
+            parentID: parentID,
+            siteID: "site-1",
+            courseID: courseID,
+            remoteID: 0,
+            filename: id,
+            isDirectory: false,
+            syncState: .placeholder
+        )
+    }
+
+    func testChangeCounterIncrementsOnItemInsert() throws {
+        let before = try database.currentChangeCounter()
+        try database.saveItems([makeItem(id: "item-1")])
+        let after = try database.currentChangeCounter()
+        XCTAssertGreaterThan(after, before)
+    }
+
+    func testChangeCounterIncrementsOnItemUpdate() throws {
+        try database.saveItems([makeItem(id: "item-1")])
+        let afterInsert = try database.currentChangeCounter()
+        try database.updateItemFilename(id: "item-1", filename: "renamed")
+        let afterUpdate = try database.currentChangeCounter()
+        XCTAssertGreaterThan(afterUpdate, afterInsert)
+    }
+
+    func testFetchItemsChangedSinceFiltersByAnchor() throws {
+        try database.saveItems([makeItem(id: "old-1")])
+        let anchor = try database.currentChangeCounter()
+        try database.saveItems([makeItem(id: "new-1"), makeItem(id: "new-2")])
+
+        // Whole-site lookup should return only the items inserted after the anchor.
+        let changed = try database.fetchItemsChangedSince(anchor: anchor, siteID: "site-1")
+        let changedIDs = Set(changed.map(\.id))
+        XCTAssertEqual(changedIDs, Set(["new-1", "new-2"]))
+    }
+
+    func testFetchPendingDeletionsSinceFiltersByAnchor() throws {
+        try database.saveItems([
+            makeItem(id: "to-keep"),
+            makeItem(id: "to-delete-1"),
+            makeItem(id: "to-delete-2"),
+        ])
+        let anchor = try database.currentChangeCounter()
+
+        try database.deleteItemsWithTombstone(ids: ["to-delete-1"])
+        try database.deleteItemsWithTombstone(ids: ["to-delete-2"])
+
+        let deletedSince = try database.fetchPendingDeletionsSince(anchor: anchor)
+        XCTAssertEqual(Set(deletedSince), Set(["to-delete-1", "to-delete-2"]))
+
+        // An anchor newer than both deletions should return nothing.
+        let nowAnchor = try database.currentChangeCounter()
+        XCTAssertTrue(try database.fetchPendingDeletionsSince(anchor: nowAnchor).isEmpty)
+    }
 }

--- a/Tests/SharedDomainTests/ModelTests.swift
+++ b/Tests/SharedDomainTests/ModelTests.swift
@@ -96,4 +96,14 @@ final class ModelTests: XCTestCase {
         XCTAssertEqual(cursor.siteID, "test")
         XCTAssertEqual(cursor.itemCount, 0)
     }
+
+    func testRequiresReauthentication() {
+        XCTAssertTrue(FoodleError.tokenExpired.requiresReauthentication)
+        XCTAssertTrue(FoodleError.tokenRefreshFailed(underlying: "x").requiresReauthentication)
+        XCTAssertTrue(FoodleError.authenticationRequired.requiresReauthentication)
+
+        XCTAssertFalse(FoodleError.networkUnavailable.requiresReauthentication)
+        XCTAssertFalse(FoodleError.timeout.requiresReauthentication)
+        XCTAssertFalse(FoodleError.invalidCredentials.requiresReauthentication)
+    }
 }

--- a/Tests/SyncEngineTests/SyncEngineCourseScopeTests.swift
+++ b/Tests/SyncEngineTests/SyncEngineCourseScopeTests.swift
@@ -101,6 +101,95 @@ final class SyncEngineCourseScopeTests: XCTestCase {
         XCTAssertEqual(refreshedUntouchedRoot.syncState, .materialized)
         XCTAssertEqual(refreshedUntouchedItem.syncState, .materialized)
     }
+
+    func testSyncCoursePreservesItemTagDataWhenRemoteFileChanges() async throws {
+        let site = MoodleSite(
+            id: "site-1",
+            displayName: "Example",
+            baseURL: URL(string: "https://moodle.example.edu")!,
+            capabilities: SiteCapabilities(
+                supportsWebServices: true,
+                supportsMobileAPI: true,
+                supportsFileDownload: true
+            )
+        )
+        let token = AuthToken(token: "token")
+        let course = MoodleCourse(id: 101, shortName: "C101", fullName: "Course 101", siteID: site.id)
+        let tagData = FinderTag.tagData(from: [FinderTag(name: "Read later", color: .blue)])
+        let modifiedDate = Date(timeIntervalSince1970: 2_000)
+
+        try database.saveItems([
+            LocalItem(
+                id: "course-\(site.id)-\(course.id)",
+                parentID: nil,
+                siteID: site.id,
+                courseID: course.id,
+                remoteID: course.id,
+                filename: course.effectiveFolderName,
+                isDirectory: true,
+                syncState: .materialized
+            ),
+            LocalItem(
+                id: "section-\(site.id)-\(course.id)-11",
+                parentID: "course-\(site.id)-\(course.id)",
+                siteID: site.id,
+                courseID: course.id,
+                remoteID: 11,
+                filename: "Week 1",
+                isDirectory: true,
+                syncState: .materialized
+            ),
+            LocalItem(
+                id: "file-\(site.id)-\(course.id)-301-notes.pdf",
+                parentID: "section-\(site.id)-\(course.id)-11",
+                siteID: site.id,
+                courseID: course.id,
+                remoteID: 301,
+                filename: "notes.pdf",
+                isDirectory: false,
+                fileSize: 100,
+                syncState: .materialized,
+                contentVersion: "1000",
+                tagData: tagData
+            ),
+        ])
+
+        let provider = FakeLMSProvider(courseContents: [
+            course.id: [
+                MoodleSection(
+                    id: 11,
+                    courseID: course.id,
+                    name: "Week 1",
+                    sectionNumber: 1,
+                    modules: [
+                        MoodleModule(
+                            id: 301,
+                            name: "Notes",
+                            modName: ResourceType.file.rawValue,
+                            contents: [
+                                MoodleFileContent(
+                                    type: "file",
+                                    fileName: "notes.pdf",
+                                    fileSize: 200,
+                                    fileURL: URL(string: "https://moodle.example.edu/pluginfile.php/notes.pdf"),
+                                    timeModified: modifiedDate,
+                                    mimeType: "application/pdf"
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
+            ],
+        ])
+        let engine = SyncEngine(provider: provider, database: database)
+
+        try await engine.syncCourse(site: site, token: token, course: course)
+
+        let refreshedItem = try XCTUnwrap(database.fetchItem(id: "file-\(site.id)-\(course.id)-301-notes.pdf"))
+        XCTAssertEqual(refreshedItem.fileSize, 200)
+        XCTAssertEqual(refreshedItem.contentVersion, String(Int(modifiedDate.timeIntervalSince1970)))
+        XCTAssertEqual(refreshedItem.tagData, tagData)
+    }
 }
 
 private struct FakeLMSProvider: LMSProvider {

--- a/Tests/SyncEngineTests/SyncEngineCourseScopeTests.swift
+++ b/Tests/SyncEngineTests/SyncEngineCourseScopeTests.swift
@@ -92,14 +92,21 @@ final class SyncEngineCourseScopeTests: XCTestCase {
         try await engine.syncCourse(site: site, token: token, course: syncedCourse)
 
         let refreshedSyncedRoot = try XCTUnwrap(database.fetchItem(id: syncedCourseRoot.id))
-        let refreshedStaleItem = try XCTUnwrap(database.fetchItem(id: staleCourseItem.id))
         let refreshedUntouchedRoot = try XCTUnwrap(database.fetchItem(id: untouchedCourseRoot.id))
         let refreshedUntouchedItem = try XCTUnwrap(database.fetchItem(id: untouchedCourseItem.id))
 
+        // Stale items in the synced course should be deleted (not downgraded
+        // to .placeholder) and recorded in pending_deletions so the File
+        // Provider extension can report the deletion to Finder.
+        XCTAssertNil(try database.fetchItem(id: staleCourseItem.id))
+        let pendingDeletions = try database.fetchPendingDeletions()
+        XCTAssertTrue(pendingDeletions.contains(staleCourseItem.id))
+
         XCTAssertEqual(refreshedSyncedRoot.syncState, .materialized)
-        XCTAssertEqual(refreshedStaleItem.syncState, .placeholder)
         XCTAssertEqual(refreshedUntouchedRoot.syncState, .materialized)
         XCTAssertEqual(refreshedUntouchedItem.syncState, .materialized)
+        // Items belonging to other courses must not be tombstoned by this sync.
+        XCTAssertFalse(pendingDeletions.contains(untouchedCourseItem.id))
     }
 
     func testSyncCoursePreservesItemTagDataWhenRemoteFileChanges() async throws {

--- a/Tests/SyncEngineTests/SyncEngineCourseScopeTests.swift
+++ b/Tests/SyncEngineTests/SyncEngineCourseScopeTests.swift
@@ -228,7 +228,7 @@ private struct FakeLMSProvider: LMSProvider {
 
     func downloadFile(url: URL, token: AuthToken, destination: URL) async throws {}
 
-    func authenticatedFileURL(fileURL: URL, token: AuthToken) -> URL {
-        fileURL
+    func authenticatedFileRequest(fileURL: URL, token: AuthToken) -> URLRequest {
+        URLRequest(url: fileURL)
     }
 }

--- a/Tests/SyncEngineTests/SyncEngineReauthTests.swift
+++ b/Tests/SyncEngineTests/SyncEngineReauthTests.swift
@@ -1,0 +1,97 @@
+// Copyright 2026 Alejandro Modroño Vara <amodrono@alu.icai.comillas.edu>
+//
+// Licensed under the Apache License, Version 2.0.
+// You may obtain a copy of the License in the LICENSE file at the root of this repository.
+
+import XCTest
+@testable import SharedDomain
+@testable import FoodleNetworking
+@testable import FoodlePersistence
+@testable import FoodleSyncEngine
+
+final class SyncEngineReauthTests: XCTestCase {
+    var database: Database!
+    var tempPath: String!
+
+    private let site = MoodleSite(
+        id: "site-1",
+        displayName: "Example",
+        baseURL: URL(string: "https://moodle.example.edu")!,
+        capabilities: SiteCapabilities(
+            supportsWebServices: true,
+            supportsMobileAPI: true,
+            supportsFileDownload: true
+        )
+    )
+    private let token = AuthToken(token: "token")
+
+    override func setUp() async throws {
+        tempPath = NSTemporaryDirectory() + "foodle_reauth_test_\(UUID().uuidString).db"
+        database = try Database(path: tempPath)
+    }
+
+    override func tearDown() async throws {
+        database = nil
+        try? FileManager.default.removeItem(atPath: tempPath)
+    }
+
+    func testSyncAllCoursesRethrowsAuthenticationFailure() async throws {
+        let provider = ThrowingLMSProvider(error: .tokenExpired)
+        let engine = SyncEngine(provider: provider, database: database)
+        let courses = [MoodleCourse(id: 1, shortName: "C1", fullName: "Course 1", siteID: site.id)]
+
+        do {
+            try await engine.syncAllCourses(site: site, token: token, courses: courses)
+            XCTFail("Expected syncAllCourses to rethrow the authentication failure")
+        } catch let error as FoodleError {
+            XCTAssertTrue(error.requiresReauthentication)
+        }
+    }
+
+    func testSyncAllCoursesContinuesPastNonAuthFailure() async throws {
+        // A non-auth failure on one course must not abort the whole pass.
+        let provider = ThrowingLMSProvider(error: .networkUnavailable)
+        let engine = SyncEngine(provider: provider, database: database)
+        let courses = [
+            MoodleCourse(id: 1, shortName: "C1", fullName: "Course 1", siteID: site.id),
+            MoodleCourse(id: 2, shortName: "C2", fullName: "Course 2", siteID: site.id),
+        ]
+
+        // Should complete without throwing even though every course errors.
+        try await engine.syncAllCourses(site: site, token: token, courses: courses)
+    }
+}
+
+private struct ThrowingLMSProvider: LMSProvider {
+    let error: FoodleError
+
+    func validateSite(url: URL) async throws -> MoodleSite {
+        MoodleSite(displayName: url.host ?? "Test", baseURL: url)
+    }
+
+    func authenticate(site: MoodleSite, username: String, password: String) async throws -> AuthToken {
+        AuthToken(token: "test-token")
+    }
+
+    func parseTokenFromSSOCallback(callbackURLString: String, site: MoodleSite, passport: String) throws -> AuthToken {
+        AuthToken(token: "test-token")
+    }
+
+    func fetchUserInfo(site: MoodleSite, token: AuthToken) async throws -> MoodleUser {
+        MoodleUser(id: 1, username: "test", fullName: "Test User", siteID: site.id)
+    }
+
+    func fetchCourses(site: MoodleSite, token: AuthToken, userID: Int) async throws -> [MoodleCourse] {
+        []
+    }
+
+    func fetchCourseContents(site: MoodleSite, token: AuthToken, courseID: Int) async throws -> [MoodleSection] {
+        throw error
+    }
+
+    func downloadFile(url: URL, token: AuthToken, destination: URL) async throws {}
+
+    func authenticatedFileRequest(fileURL: URL, token: AuthToken) -> URLRequest {
+        URLRequest(url: fileURL)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -75,7 +75,7 @@ schemes:
 packages:
   Airlock:
     url: https://github.com/alexmodrono/Airlock
-    from: 0.1.1
+    from: 0.2.1
   Sparkle:
     url: https://github.com/sparkle-project/Sparkle
     from: 2.6.0


### PR DESCRIPTION
## Summary

Release 0.1.3. Hardens sync/File Provider reliability, surfaces failures that were previously invisible, adds session recovery and progress reporting, updates the Airlock onboarding dependency, and fixes the onboarding window chrome.

## Changes

**Sync anchor**
- The change-counter triggers and indexes were defined in both `createSchema()` and the v11 migration; since the migration runs on fresh databases too, the duplicates are removed and the migration is the single source of truth.
- Tombstones are no longer cleared after being reported — with two enumerators reporting against independent anchors, the early clear could hide a deletion from the second enumerator.

**Dependencies**
- Update Airlock to 0.2.1 (`immersiveIntroOnly` → `hidesOtherAppsDuringIntro`).

**File Provider hardening**
- Reject reparenting a local item under a missing parent or one of its own descendants (prevents orphaned items and directory cycles).
- Sweep `LocalContent/` once per extension instance for files with no backing local item, reclaiming leaks from partial create/modify/delete failures.
- Log (instead of silently swallowing) failures to reset an item's state after a failed download.

**Reliability & UX**
- Surface sync failures in the workspace (dismissible banner) and menu bar instead of only in Diagnostics.
- Detect authentication failures and present a "Reconnect" prompt, stopping the auto-sync loop rather than dead-ending on a generic error.
- Reset items stranded in `.downloading` on launch so they don't appear perpetually in progress.
- Show per-course progress ("Syncing X of Y") during a sync-all pass.
- Wire up the previously-inert "Notify when sync completes" setting to a local notification.

**Onboarding**
- Switch the window to `.hiddenTitleBar` so the title bar no longer floats over the transparent onboarding card (required by Airlock 0.2.x).

## Testing
- `xcodebuild` build succeeds.
- Full test suite passes, including new coverage for `resetStaleDownloads`, `FoodleError.requiresReauthentication`, and `syncAllCourses` auth-abort / continue-past-non-auth behavior.
