### PR TITLE
Fix v0.2.0 release: stop archiving the MCP helper as a standalone product

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -282,6 +282,12 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: es.amodrono.foodle.mcp
+        # The helper ships only as an embedded copy inside the app (via the app's
+        # copy phase). Without this, the tool also installs to the archive's
+        # Products/usr/local/bin, making the archive multi-product: Xcode then
+        # omits ApplicationProperties and -exportArchive fails to determine a
+        # distribution method ("Unknown Distribution Error").
+        SKIP_INSTALL: true
         # Inherit the team signing identity (no ad-hoc override) so the bundled
         # helper's Team ID matches the app's frameworks — otherwise the hardened
         # runtime's library validation refuses to load them (different Team IDs).


### PR DESCRIPTION
The v0.2.0 release archive failed at `Export archive` because the bundled `FindleMCP` command-line tool installed into `Products/usr/local/bin` as a second archive product. That made the archive multi-product, so Xcode omitted `ApplicationProperties` and `-exportArchive` couldn't determine a distribution method ("Unknown Distribution Error").

`SKIP_INSTALL = YES` keeps the helper as an embedded copy in the app only (via the copy phase), restoring a single-app archive. Verified locally: the archive now contains only `Applications/Findle.app`, `ApplicationProperties` is present, and `Contents/MacOS/FindleMCP` is still embedded.

Also includes the earlier fix to Developer ID-sign the bundled helper in the release workflow.